### PR TITLE
feat(dashboard): financial fallback to /estadocuentaestudiantes when /pagos is unavailable

### DIFF
--- a/src/q10/dashboard.service.ts
+++ b/src/q10/dashboard.service.ts
@@ -73,6 +73,12 @@ export class DashboardService {
 
   async overview(rangeDays = 30) {
     const errors: Record<string, string> = {};
+    // Tracks per-KPI notes when a value had to be derived from a fallback
+    // source instead of the primary endpoint. The frontend can surface
+    // these as caveats next to the affected numbers so operators know the
+    // figure came from a degraded path (e.g. lifetime total instead of a
+    // range-filtered sum).
+    const degraded: Record<string, string> = {};
 
     const [
       students,
@@ -82,6 +88,7 @@ export class DashboardService {
       orders,
       payments,
       pending,
+      estadoCuenta,
     ] = await Promise.all([
       this.tryFetch<Item>('students', '/estudiantes', errors),
       this.tryFetch<Item>('opportunities', '/oportunidades', errors),
@@ -90,6 +97,14 @@ export class DashboardService {
       this.tryFetch<Item>('orders', '/ordenespago', errors),
       this.tryFetch<Item>('payments', '/pagos', errors),
       this.tryFetch<Item>('pendingPayments', '/pagospendientes', errors),
+      // Financial fallback source. Many Q10 subscription plans (including
+      // our production plan) do NOT expose /pagos or /pagospendientes —
+      // only /estadocuentaestudiantes. When the primary endpoints fail we
+      // derive outstanding-debt and lifetime-paid figures from here so the
+      // dashboard still shows meaningful numbers instead of zeros. The
+      // sibling Q10 WhatsApp Chrome extension hit the same limitation and
+      // documented it in its background/service-worker.js.
+      this.tryFetch<Item>('accountStatements', '/estadocuentaestudiantes', errors),
     ]);
 
     // ─── Students ───
@@ -111,12 +126,40 @@ export class DashboardService {
 
     // ─── Financial ───
     const paidInRange = payments.filter((p) => withinLastDays(p.Fecha_pago, rangeDays));
-    const revenueInRange = sum(paidInRange, 'Valor');
-    const outstandingDebt = sum(pending, 'Valor');
+    const estadoCuentaAvailable = !errors['accountStatements'];
+
+    // revenueInRange: prefer /pagos (supports Fecha_pago range filter). Fall
+    // back to /estadocuentaestudiantes.Total_pagado (a lifetime figure, NOT
+    // range-filtered — the degraded note makes that caveat explicit so the
+    // frontend can badge the KPI).
+    let revenueInRange = sum(paidInRange, 'Valor');
+    if (errors['payments'] && estadoCuentaAvailable) {
+      revenueInRange = sum(estadoCuenta, 'Total_pagado');
+      degraded['revenueInRange'] =
+        'Derived from estadocuentaestudiantes (lifetime total, not range-filtered)';
+    }
+
+    // outstandingDebt: prefer /pagospendientes (Valor per pending item). Fall
+    // back to /estadocuentaestudiantes.Saldo (current balance due per student).
+    let outstandingDebt = sum(pending, 'Valor');
+    if (errors['pendingPayments'] && estadoCuentaAvailable) {
+      outstandingDebt = sum(estadoCuenta, 'Saldo');
+      degraded['outstandingDebt'] =
+        'Derived from estadocuentaestudiantes (Saldo aggregate)';
+    }
+
+    // overduePending: requires per-item Fecha_vencimiento. estadoCuenta has
+    // no due-date field, so there is no viable fallback — we surface 0 and
+    // explain why via the degraded note.
     const overduePending = pending.filter((p) => {
       const due = parseDate(p.Fecha_vencimiento);
       return due !== null && due.getTime() < Date.now();
     });
+    if (errors['pendingPayments']) {
+      degraded['overduePending'] =
+        'Unavailable: estadocuentaestudiantes has no due-date field';
+    }
+
     const ordersPending = orders.filter((o) =>
       String(o.Estado ?? '').toLowerCase().includes('pend'),
     );
@@ -130,7 +173,16 @@ export class DashboardService {
       ).length,
     };
 
-    const revenueByDay = this.bucketByDay(paidInRange, 'Fecha_pago', 'Valor', rangeDays);
+    // revenueByDay: requires per-payment dates. When /pagos fails there is
+    // no viable fallback (estadoCuenta has no Fecha_pago), so we emit an
+    // empty series and flag the chart as degraded.
+    const revenueByDay = errors['payments']
+      ? []
+      : this.bucketByDay(paidInRange, 'Fecha_pago', 'Valor', rangeDays);
+    if (errors['payments']) {
+      degraded['revenueByDay'] =
+        'Unavailable: estadocuentaestudiantes has no per-payment dates';
+    }
     const newStudentsByDay = this.bucketByDay(
       newStudentsInRange,
       'Fecha_creacion',
@@ -146,6 +198,7 @@ export class DashboardService {
       range: { days: rangeDays, generatedAt: new Date().toISOString() },
       partial: Object.keys(errors).length > 0,
       errors,
+      degraded,
       kpis: {
         activeStudents: activeStudents.length,
         totalStudents: students.length,

--- a/test/dashboard.e2e-spec.ts
+++ b/test/dashboard.e2e-spec.ts
@@ -4,7 +4,78 @@ import cookieParser = require('cookie-parser');
 import request = require('supertest');
 import { AppModule } from '../src/app.module';
 import { Q10ClientService } from '../src/q10/q10-client.service';
+import {
+  estadocuentaestudiantes,
+  estudiantes,
+  matriculas,
+  negocios,
+  oportunidades,
+  ordenesDePago,
+  pagos,
+  pagosPendientes,
+} from '../src/q10/mock/mock-data';
 import { loginAsAdmin } from './helpers/app';
+
+/**
+ * Build a Q10 client double whose `.get` resolves mock data for most
+ * endpoints but rejects for the paths listed in `rejectPaths`. Used to
+ * simulate Q10 subscription plans that don't expose `/pagos` or
+ * `/pagospendientes` (the production plan only exposes
+ * `/estadocuentaestudiantes` — same limitation hit by the sibling Q10
+ * WhatsApp Chrome extension).
+ */
+function buildQ10ClientStub(rejectPaths: string[]) {
+  const shouldReject = (path: string) =>
+    rejectPaths.some((r) => path.toLowerCase().includes(r.toLowerCase()));
+
+  const datasetFor = (path: string): unknown[] => {
+    const p = path.toLowerCase();
+    // /estadocuentaestudiantes must be matched BEFORE /estudiantes since
+    // the former is a superstring of the latter.
+    if (p.includes('estadocuentaestudiantes')) return estadocuentaestudiantes;
+    if (p.includes('estudiantes')) return estudiantes;
+    if (p.includes('oportunidades')) return oportunidades;
+    if (p.includes('negocios')) return negocios;
+    if (p.includes('matricula')) return matriculas;
+    if (p.includes('ordenespago') || p.includes('ordenesdepago')) return ordenesDePago;
+    // /pagospendientes must be matched BEFORE /pagos (superstring rule).
+    if (p.includes('pagospendientes')) return pagosPendientes;
+    if (p.includes('pagos')) return pagos;
+    return [];
+  };
+
+  return {
+    get: jest.fn((path: string) => {
+      if (shouldReject(path)) {
+        return Promise.reject(new Error(`Q10 ${path} unavailable on this plan`));
+      }
+      return Promise.resolve(datasetFor(path));
+    }),
+    post: jest.fn(),
+    put: jest.fn(),
+    patch: jest.fn(),
+    delete: jest.fn(),
+    raw: jest.fn(),
+    clearCache: jest.fn(),
+  };
+}
+
+async function bootApp(clientOverride?: unknown) {
+  const builder = Test.createTestingModule({ imports: [AppModule] });
+  if (clientOverride !== undefined) {
+    builder.overrideProvider(Q10ClientService).useValue(clientOverride);
+  }
+  const moduleRef = await builder.compile();
+
+  const app = moduleRef.createNestApplication();
+  app.use(cookieParser());
+  app.useGlobalPipes(
+    new ValidationPipe({ whitelist: true, forbidNonWhitelisted: true, transform: true }),
+  );
+  app.setGlobalPrefix('api');
+  await app.init();
+  return app;
+}
 
 describe('GET /api/dashboard/overview — partial state (#5 round 2)', () => {
   let app: any;
@@ -17,29 +88,15 @@ describe('GET /api/dashboard/overview — partial state (#5 round 2)', () => {
   it('returns partial:true and per-source errors when Q10 fetches fail', async () => {
     // Build a custom test app where Q10ClientService.get always rejects so
     // every dashboard source ends up in the errors map.
-    const moduleRef = await Test.createTestingModule({
-      imports: [AppModule],
-    })
-      .overrideProvider(Q10ClientService)
-      .useValue({
-        get: jest.fn().mockRejectedValue(new Error('Q10 unreachable')),
-        post: jest.fn(),
-        put: jest.fn(),
-        patch: jest.fn(),
-        delete: jest.fn(),
-        raw: jest.fn(),
-        clearCache: jest.fn(),
-      })
-      .compile();
-
-    app = moduleRef.createNestApplication();
-    app.use(cookieParser());
-    app.useGlobalPipes(
-      new ValidationPipe({ whitelist: true, forbidNonWhitelisted: true, transform: true }),
-    );
-    app.setGlobalPrefix('api');
-    await app.init();
-
+    app = await bootApp({
+      get: jest.fn().mockRejectedValue(new Error('Q10 unreachable')),
+      post: jest.fn(),
+      put: jest.fn(),
+      patch: jest.fn(),
+      delete: jest.fn(),
+      raw: jest.fn(),
+      clearCache: jest.fn(),
+    });
     cookie = await loginAsAdmin(app);
 
     const resp = await request(app.getHttpServer())
@@ -58,18 +115,7 @@ describe('GET /api/dashboard/overview — partial state (#5 round 2)', () => {
   });
 
   it('returns partial:false when all sources succeed', async () => {
-    const moduleRef = await Test.createTestingModule({
-      imports: [AppModule],
-    }).compile();
-
-    app = moduleRef.createNestApplication();
-    app.use(cookieParser());
-    app.useGlobalPipes(
-      new ValidationPipe({ whitelist: true, forbidNonWhitelisted: true, transform: true }),
-    );
-    app.setGlobalPrefix('api');
-    await app.init();
-
+    app = await bootApp();
     cookie = await loginAsAdmin(app);
 
     const resp = await request(app.getHttpServer())
@@ -79,5 +125,121 @@ describe('GET /api/dashboard/overview — partial state (#5 round 2)', () => {
 
     expect(resp.body.partial).toBe(false);
     expect(resp.body.errors).toEqual({});
+    // `degraded` is always present in the response — empty when nothing
+    // had to be derived from a fallback source.
+    expect(resp.body.degraded).toEqual({});
+  });
+
+  it('falls back to /estadocuentaestudiantes when /pagos and /pagospendientes fail', async () => {
+    // Simulates the production Q10 plan: /pagos and /pagospendientes are
+    // NOT exposed, but /estadocuentaestudiantes is. This limitation was
+    // discovered in the sibling Q10 WhatsApp Chrome extension project.
+    app = await bootApp(buildQ10ClientStub(['/pagospendientes', '/pagos']));
+    cookie = await loginAsAdmin(app);
+
+    const resp = await request(app.getHttpServer())
+      .get('/api/dashboard/overview?range=30')
+      .set('Cookie', cookie)
+      .expect(200);
+
+    // Primary sources still report errors → partial remains true.
+    expect(resp.body.partial).toBe(true);
+    expect(resp.body.errors.payments).toEqual(expect.any(String));
+    expect(resp.body.errors.pendingPayments).toEqual(expect.any(String));
+    // estadocuentaestudiantes itself must NOT be in errors.
+    expect(resp.body.errors.accountStatements).toBeUndefined();
+
+    // Fallback KPIs derived from estadocuentaestudiantes sample data.
+    const expectedSaldo = estadocuentaestudiantes.reduce(
+      (acc, e) => acc + (Number(e.Saldo) || 0),
+      0,
+    );
+    const expectedTotalPagado = estadocuentaestudiantes.reduce(
+      (acc, e) => acc + (Number(e.Total_pagado) || 0),
+      0,
+    );
+    expect(resp.body.kpis.outstandingDebt).toBe(expectedSaldo);
+    expect(resp.body.kpis.revenueInRange).toBe(expectedTotalPagado);
+    // overduePending has no fallback (no due-date field in estadoCuenta).
+    expect(resp.body.kpis.overduePending).toBe(0);
+
+    // Degraded notes are populated for the affected KPIs.
+    expect(resp.body.degraded.revenueInRange).toMatch(/estadocuentaestudiantes/);
+    expect(resp.body.degraded.outstandingDebt).toMatch(/estadocuentaestudiantes/);
+    expect(resp.body.degraded.overduePending).toMatch(/due-date|Unavailable/i);
+    expect(resp.body.degraded.revenueByDay).toMatch(/per-payment dates|Unavailable/i);
+
+    // Non-financial KPIs are unaffected — students / opportunities / deals
+    // still populate from their own endpoints.
+    expect(resp.body.kpis.totalStudents).toBe(estudiantes.length);
+    expect(resp.body.kpis.activeDeals).toBe(negocios.length);
+
+    // revenueByDay chart is empty (no dated rows available).
+    expect(resp.body.charts.revenueByDay).toEqual([]);
+  });
+
+  it('keeps existing behaviour when ALL financial sources fail', async () => {
+    app = await bootApp(
+      buildQ10ClientStub([
+        '/pagospendientes',
+        '/pagos',
+        '/estadocuentaestudiantes',
+      ]),
+    );
+    cookie = await loginAsAdmin(app);
+
+    const resp = await request(app.getHttpServer())
+      .get('/api/dashboard/overview?range=30')
+      .set('Cookie', cookie)
+      .expect(200);
+
+    expect(resp.body.partial).toBe(true);
+    expect(resp.body.errors.payments).toEqual(expect.any(String));
+    expect(resp.body.errors.pendingPayments).toEqual(expect.any(String));
+    expect(resp.body.errors.accountStatements).toEqual(expect.any(String));
+
+    // Without any financial source there is nothing to fall back to.
+    expect(resp.body.kpis.revenueInRange).toBe(0);
+    expect(resp.body.kpis.outstandingDebt).toBe(0);
+    expect(resp.body.kpis.overduePending).toBe(0);
+    expect(resp.body.charts.revenueByDay).toEqual([]);
+
+    // Since estadoCuenta was not available, revenueInRange/outstandingDebt
+    // were NOT recomputed from it, so there is no degraded entry for them.
+    expect(resp.body.degraded.revenueInRange).toBeUndefined();
+    expect(resp.body.degraded.outstandingDebt).toBeUndefined();
+  });
+
+  it('uses estadoCuenta only for outstandingDebt when only /pagospendientes fails', async () => {
+    app = await bootApp(buildQ10ClientStub(['/pagospendientes']));
+    cookie = await loginAsAdmin(app);
+
+    // Wide range so the fixed mock /pagos dates still fall inside the
+    // window and feed the primary revenue path.
+    const resp = await request(app.getHttpServer())
+      .get('/api/dashboard/overview?range=3650')
+      .set('Cookie', cookie)
+      .expect(200);
+
+    expect(resp.body.partial).toBe(true);
+    expect(resp.body.errors.pendingPayments).toEqual(expect.any(String));
+    expect(resp.body.errors.payments).toBeUndefined();
+    expect(resp.body.errors.accountStatements).toBeUndefined();
+
+    // Fallback kicks in for outstandingDebt only.
+    const expectedSaldo = estadocuentaestudiantes.reduce(
+      (acc, e) => acc + (Number(e.Saldo) || 0),
+      0,
+    );
+    expect(resp.body.kpis.outstandingDebt).toBe(expectedSaldo);
+    expect(resp.body.degraded.outstandingDebt).toMatch(/estadocuentaestudiantes/);
+
+    // revenueInRange stays on the primary /pagos path (not fallback), so
+    // no degraded entry for it and revenueByDay chart is still populated.
+    expect(resp.body.degraded.revenueInRange).toBeUndefined();
+    expect(resp.body.degraded.revenueByDay).toBeUndefined();
+    const expectedRevenue = pagos.reduce((a, p) => a + (Number(p.Valor) || 0), 0);
+    expect(resp.body.kpis.revenueInRange).toBe(expectedRevenue);
+    expect(Array.isArray(resp.body.charts.revenueByDay)).toBe(true);
   });
 });


### PR DESCRIPTION
Adds a financial fallback so the dashboard stays useful when the `/pagos` and `/pagospendientes` endpoints aren't available in the Q10 subscription plan.

## Why

The Q10 WhatsApp extension (`diogenesmendes01/q10-whatsapp-plugin`, `background/service-worker.js:247`) documents that those endpoints aren't in the current Q10 plan — only `/estadocuentaestudiantes` is. Without this fix, the dashboard would show the "Datos parciales" banner permanently in production.

## Changes

- `src/q10/dashboard.service.ts`: fifth `tryFetch` for `/estadocuentaestudiantes`; new top-level `degraded: Record<string, string>` next to `partial`/`errors`; fallback logic for:
  - `outstandingDebt` — sum of `Saldo` when pending-payments source failed
  - `revenueInRange` — sum of `Total_pagado` (marked lifetime, not range-filtered)
  - `overduePending` / `revenueByDay` — annotated as degraded when input unavailable

- `test/dashboard.e2e-spec.ts`: 3 new scenarios (pagos+pagospendientes fail / all three fail / only pagospendientes fails) using a reusable `buildQ10ClientStub` helper.

## Test plan

- [x] `npm run build` clean
- [x] `npm test` — 32 tests passing (was 29)
- [ ] After deploy: verify dashboard renders with `degraded.revenueInRange` message if `/pagos` returns 403 in production
- [ ] Confirm Q10 support: is there a way to enable `/pagos` on our plan, or is this the permanent behavior?

https://claude.ai/code/session_01GJarYvsaJrh1SZPznRsiDo