### PR TITLE
feat(q10): shared phone/name matching lib + extend catalogs with mediospublicitarios & medioscontacto

### DIFF
--- a/src/q10/matching.ts
+++ b/src/q10/matching.ts
@@ -20,8 +20,11 @@ const COMBINING_DIACRITICS = /[̀-ͯ]/g;
  * `5555 1234`, or `045551234` depending on who typed it — this folds all
  * three into a comparable canonical form.
  */
-export function normalizePhone(raw: string | null | undefined): string {
-  let digits = (raw || '').replace(/\D/g, '');
+export function normalizePhone(raw: unknown): string {
+  // Coerce defensively — Q10 occasionally returns phone fields as numbers
+  // (e.g. when a record was imported from a spreadsheet), and calling
+  // `.replace` on a number would throw "replace is not a function".
+  let digits = String(raw ?? '').replace(/\D/g, '');
   // Remove leading 0 (local format) — only for short-ish numbers to avoid
   // stripping the first digit of a legitimate international number.
   if (digits.startsWith('0') && digits.length <= 11) digits = digits.slice(1);
@@ -40,8 +43,8 @@ export function phoneMatches(
   contactPhone: unknown,
   searchPhone: unknown,
 ): boolean {
-  const a = normalizePhone(contactPhone as string | null | undefined);
-  const b = normalizePhone(searchPhone as string | null | undefined);
+  const a = normalizePhone(contactPhone);
+  const b = normalizePhone(searchPhone);
   if (!a || !b) return false;
   // Exact match on canonical digits.
   if (a === b) return true;

--- a/src/q10/matching.ts
+++ b/src/q10/matching.ts
@@ -1,0 +1,116 @@
+/**
+ * Phone + name matching helpers, ported from the Q10 WhatsApp plugin
+ * (background/service-worker.js). Used whenever we need to reconcile a
+ * WhatsApp contact against Q10's `usuarios`/`contactos`/`oportunidades`
+ * records, which store phone numbers and names in inconsistent shapes.
+ *
+ * Keep behaviour in lock-step with the plugin — downstream searches and
+ * opportunity lookups depend on the exact same matching semantics.
+ */
+
+// Combining diacritics block U+0300..U+036F — stripped after NFD
+// decomposition so "María" becomes "Maria".
+const COMBINING_DIACRITICS = /[̀-ͯ]/g;
+
+/**
+ * Strips everything but digits and drops a leading "0" for local-format
+ * numbers (e.g. Guatemalan mobile dialled inside country as `0 4512 3489`).
+ *
+ * Real-world case: the same contact may appear as `+502 5555-1234`,
+ * `5555 1234`, or `045551234` depending on who typed it — this folds all
+ * three into a comparable canonical form.
+ */
+export function normalizePhone(raw: string | null | undefined): string {
+  let digits = (raw || '').replace(/\D/g, '');
+  // Remove leading 0 (local format) — only for short-ish numbers to avoid
+  // stripping the first digit of a legitimate international number.
+  if (digits.startsWith('0') && digits.length <= 11) digits = digits.slice(1);
+  return digits;
+}
+
+/**
+ * Returns true when two phone values belong to the same person.
+ *
+ * Real-world case: country code and area code vary between how the CRM
+ * stored the number and how WhatsApp surfaces it. The last-8-digits
+ * fallback handles varying country code + area code formats (e.g.
+ * `+50255551234` in Q10 vs `55551234` saved as a local contact).
+ */
+export function phoneMatches(
+  contactPhone: unknown,
+  searchPhone: unknown,
+): boolean {
+  const a = normalizePhone(contactPhone as string | null | undefined);
+  const b = normalizePhone(searchPhone as string | null | undefined);
+  if (!a || !b) return false;
+  // Exact match on canonical digits.
+  if (a === b) return true;
+  // One contains the other — handles country-code prefix differences.
+  if (a.endsWith(b) || b.endsWith(a)) return true;
+  // Last 8 digits match handles varying country code + area code formats.
+  if (a.length >= 8 && b.length >= 8 && a.slice(-8) === b.slice(-8)) {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Returns true when `searchName` matches the person represented by
+ * `record`, using accent-insensitive, word-order-independent fuzzy match.
+ *
+ * Real-world case: the WhatsApp display name is "Maria Lopez" but Q10
+ * stores it as `Primer_nombre="María"` + `Primer_apellido="López"` (or
+ * `Nombres` + `Apellidos`, depending on the endpoint). Accent-insensitive
+ * (NFD + strip U+0300..U+036F) and word-order-independent matching lets
+ * us pair them up regardless of how the record is shaped.
+ */
+export function nameMatches(
+  record: Record<string, unknown>,
+  searchName: string,
+): boolean {
+  if (!searchName) return false;
+  const search = searchName
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(COMBINING_DIACRITICS, '');
+
+  // Build full name from record fields — different Q10 endpoints expose
+  // name components under different keys, so we union them all.
+  const parts = [
+    record.Nombres,
+    record.Apellidos,
+    record.Primer_nombre,
+    record.Segundo_nombre,
+    record.Primer_apellido,
+    record.Segundo_apellido,
+    record.Nombre,
+    record.nombre,
+    record.Nombre_completo,
+  ].filter(Boolean) as string[];
+
+  const fullName = parts
+    .join(' ')
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(COMBINING_DIACRITICS, '');
+
+  if (!fullName) return false;
+
+  // Exact match.
+  if (fullName === search) return true;
+
+  // Full name contains search or search contains full name.
+  if (fullName.includes(search) || search.includes(fullName)) return true;
+
+  // Match by parts: all search words must appear somewhere in the full
+  // name. Ignores single-char tokens to avoid false positives from
+  // initials. Word-order-independent handles "Maria Lopez" vs
+  // "Lopez Maria" and partial matches handle "Mari" vs "Maria".
+  const searchWords = search.split(/\s+/).filter((w) => w.length > 1);
+  const nameWords = fullName.split(/\s+/);
+  const allMatch = searchWords.every((sw) =>
+    nameWords.some((nw) => nw.includes(sw) || sw.includes(nw)),
+  );
+
+  return allMatch && searchWords.length > 0;
+}

--- a/src/q10/mock/mock-data.ts
+++ b/src/q10/mock/mock-data.ts
@@ -125,6 +125,24 @@ export const sedes = [
   },
 ];
 
+// Marketing channels used to tag where an opportunity came from.
+export const mediospublicitarios = [
+  { Codigo: 'MP-001', Nombre: 'Facebook Ads', Estado: 'Activo' },
+  { Codigo: 'MP-002', Nombre: 'Google Ads', Estado: 'Activo' },
+  { Codigo: 'MP-003', Nombre: 'Referido', Estado: 'Activo' },
+  { Codigo: 'MP-004', Nombre: 'Volante', Estado: 'Activo' },
+  { Codigo: 'MP-005', Nombre: 'Página web', Estado: 'Activo' },
+];
+
+// How the prospect first reached out — surfaced on the opportunity form.
+export const medioscontacto = [
+  { Codigo: 'MC-001', Nombre: 'WhatsApp', Estado: 'Activo' },
+  { Codigo: 'MC-002', Nombre: 'Teléfono', Estado: 'Activo' },
+  { Codigo: 'MC-003', Nombre: 'Email', Estado: 'Activo' },
+  { Codigo: 'MC-004', Nombre: 'Visita sede', Estado: 'Activo' },
+  { Codigo: 'MC-005', Nombre: 'Formulario web', Estado: 'Activo' },
+];
+
 // ─── Contacts / Students ───
 
 export const contactos = [

--- a/src/q10/q10-mock.service.ts
+++ b/src/q10/q10-mock.service.ts
@@ -11,6 +11,8 @@ const DATASETS: Record<string, unknown[]> = {
   periodos: mock.periodos,
   sedes: mock.sedes,
   sedesjornadas: mock.sedes,
+  mediospublicitarios: mock.mediospublicitarios,
+  medioscontacto: mock.medioscontacto,
   contactos: mock.contactos,
   estudiantes: mock.estudiantes,
   usuarios: mock.estudiantes,

--- a/src/q10/q10.controller.ts
+++ b/src/q10/q10.controller.ts
@@ -34,13 +34,28 @@ export class Q10PublicController {
 
   @Get('catalogs')
   async catalogs() {
+    // `programas`/`periodos`/`sedes` are required by the matrícula form —
+    // if any of them fails the form can't render, so we let the error bubble.
+    // `mediospublicitarios` and `medioscontacto` are nice-to-have for the CRM
+    // opportunity flow; on plans that don't expose them we degrade to [] so
+    // the public endpoint stays up and the form keeps working.
+    const optional = async <T>(p: Promise<T>): Promise<T | []> => {
+      try {
+        return await p;
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        console.warn(`[catalogs] optional source failed: ${msg}`);
+        return [];
+      }
+    };
+
     const [programas, periodos, sedes, mediospublicitarios, medioscontacto] =
       await Promise.all([
         this.q10.get('/programas'),
         this.q10.get('/periodos'),
         this.q10.get('/sedes'),
-        this.q10.get('/mediospublicitarios', { Estado: true }),
-        this.q10.get('/medioscontacto', { Estado: true }),
+        optional(this.q10.get('/mediospublicitarios', { Estado: true })),
+        optional(this.q10.get('/medioscontacto', { Estado: true })),
       ]);
     return {
       programas,

--- a/src/q10/q10.controller.ts
+++ b/src/q10/q10.controller.ts
@@ -34,12 +34,21 @@ export class Q10PublicController {
 
   @Get('catalogs')
   async catalogs() {
-    const [programas, periodos, sedes] = await Promise.all([
-      this.q10.get('/programas'),
-      this.q10.get('/periodos'),
-      this.q10.get('/sedes'),
-    ]);
-    return { programas, periodos, sedes };
+    const [programas, periodos, sedes, mediospublicitarios, medioscontacto] =
+      await Promise.all([
+        this.q10.get('/programas'),
+        this.q10.get('/periodos'),
+        this.q10.get('/sedes'),
+        this.q10.get('/mediospublicitarios', { Estado: true }),
+        this.q10.get('/medioscontacto', { Estado: true }),
+      ]);
+    return {
+      programas,
+      periodos,
+      sedes,
+      mediospublicitarios,
+      medioscontacto,
+    };
   }
 
   @Post('enrollment')

--- a/test/catalogs.e2e-spec.ts
+++ b/test/catalogs.e2e-spec.ts
@@ -1,5 +1,9 @@
-import { INestApplication } from '@nestjs/common';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import cookieParser = require('cookie-parser');
 import request = require('supertest');
+import { AppModule } from '../src/app.module';
+import { Q10ClientService } from '../src/q10/q10-client.service';
 import { createTestApp } from './helpers/app';
 
 describe('GET /api/q10/catalogs', () => {
@@ -54,5 +58,66 @@ describe('GET /api/q10/catalogs', () => {
     expect(first).toHaveProperty('Codigo');
     expect(first).toHaveProperty('Nombre');
     expect(first).toHaveProperty('Estado');
+  });
+
+  /**
+   * On a Q10 plan that does not expose the CRM catalogs, the endpoint must
+   * still serve the matrícula form's required catalogs (programas/periodos/
+   * sedes). We stub Q10ClientService so just the two optional paths reject.
+   */
+  it('returns [] for optional catalogs when Q10 rejects them (form stays usable)', async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [AppModule],
+    })
+      .overrideProvider(Q10ClientService)
+      .useValue({
+        get: jest.fn(async (path: string) => {
+          if (
+            path.includes('mediospublicitarios') ||
+            path.includes('medioscontacto')
+          ) {
+            const err: any = new Error('Resource not found');
+            err.status = 404;
+            throw err;
+          }
+          // Return a plausible payload for the required catalogs.
+          if (path.includes('programas')) return [{ Codigo: 'PROG-X' }];
+          if (path.includes('periodos')) return [{ Codigo: 'PER-X' }];
+          if (path.includes('sedes')) return [{ Codigo: 'SEDE-X' }];
+          return [];
+        }),
+        post: jest.fn(),
+        put: jest.fn(),
+        patch: jest.fn(),
+        delete: jest.fn(),
+        raw: jest.fn(),
+        clearCache: jest.fn(),
+      })
+      .compile();
+
+    const localApp = moduleRef.createNestApplication();
+    localApp.use(cookieParser());
+    localApp.useGlobalPipes(
+      new ValidationPipe({
+        whitelist: true,
+        forbidNonWhitelisted: true,
+        transform: true,
+      }),
+    );
+    localApp.setGlobalPrefix('api');
+    await localApp.init();
+
+    try {
+      const resp = await request(localApp.getHttpServer())
+        .get('/api/q10/catalogs')
+        .expect(200);
+      expect(resp.body.programas).toEqual([{ Codigo: 'PROG-X' }]);
+      expect(resp.body.periodos).toEqual([{ Codigo: 'PER-X' }]);
+      expect(resp.body.sedes).toEqual([{ Codigo: 'SEDE-X' }]);
+      expect(resp.body.mediospublicitarios).toEqual([]);
+      expect(resp.body.medioscontacto).toEqual([]);
+    } finally {
+      await localApp.close();
+    }
   });
 });

--- a/test/catalogs.e2e-spec.ts
+++ b/test/catalogs.e2e-spec.ts
@@ -1,0 +1,58 @@
+import { INestApplication } from '@nestjs/common';
+import request = require('supertest');
+import { createTestApp } from './helpers/app';
+
+describe('GET /api/q10/catalogs', () => {
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    app = await createTestApp();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('returns all five catalogs as arrays', async () => {
+    const resp = await request(app.getHttpServer())
+      .get('/api/q10/catalogs')
+      .expect(200);
+
+    const expectedKeys = [
+      'programas',
+      'periodos',
+      'sedes',
+      'mediospublicitarios',
+      'medioscontacto',
+    ];
+    for (const key of expectedKeys) {
+      expect(resp.body).toHaveProperty(key);
+      expect(Array.isArray(resp.body[key])).toBe(true);
+    }
+
+    // And nothing extra beyond those five keys.
+    expect(Object.keys(resp.body).sort()).toEqual(expectedKeys.sort());
+  });
+
+  it('mediospublicitarios items carry the catalog shape', async () => {
+    const resp = await request(app.getHttpServer())
+      .get('/api/q10/catalogs')
+      .expect(200);
+    expect(resp.body.mediospublicitarios.length).toBeGreaterThan(0);
+    const first = resp.body.mediospublicitarios[0];
+    expect(first).toHaveProperty('Codigo');
+    expect(first).toHaveProperty('Nombre');
+    expect(first).toHaveProperty('Estado');
+  });
+
+  it('medioscontacto items carry the catalog shape', async () => {
+    const resp = await request(app.getHttpServer())
+      .get('/api/q10/catalogs')
+      .expect(200);
+    expect(resp.body.medioscontacto.length).toBeGreaterThan(0);
+    const first = resp.body.medioscontacto[0];
+    expect(first).toHaveProperty('Codigo');
+    expect(first).toHaveProperty('Nombre');
+    expect(first).toHaveProperty('Estado');
+  });
+});

--- a/test/jest-e2e.config.js
+++ b/test/jest-e2e.config.js
@@ -2,7 +2,10 @@
 module.exports = {
   rootDir: '..',
   testEnvironment: 'node',
-  testRegex: '.e2e-spec\\.ts$',
+  // Match both e2e specs (*.e2e-spec.ts) and plain unit specs (*.spec.ts)
+  // so we can drop pure-logic tests next to the e2e suite without
+  // introducing a second Jest config.
+  testRegex: '\\.(e2e-)?spec\\.ts$',
   transform: { '^.+\\.ts$': 'ts-jest' },
   moduleFileExtensions: ['ts', 'js', 'json'],
   setupFiles: ['<rootDir>/test/setup-env.js'],

--- a/test/matching.spec.ts
+++ b/test/matching.spec.ts
@@ -22,6 +22,16 @@ describe('normalizePhone', () => {
     expect(normalizePhone(undefined)).toBe('');
   });
 
+  it('coerces non-string input (numbers, objects) instead of throwing', () => {
+    // Q10 occasionally serializes phone fields as numbers — must not throw.
+    expect(normalizePhone(50255551234 as unknown)).toBe('50255551234');
+    // `0` gets stripped by the leading-zero rule (canonical empty), but the
+    // important part is the call doesn't throw "replace is not a function".
+    expect(() => normalizePhone(0 as unknown)).not.toThrow();
+    // Objects coerce via their default String() representation — digits only.
+    expect(normalizePhone({} as unknown)).toBe('');
+  });
+
   it('keeps leading zero on numbers longer than 11 digits (likely intl)', () => {
     // 12-digit string starting with 0 should not have the 0 stripped,
     // to avoid mangling something that isn't really local format.

--- a/test/matching.spec.ts
+++ b/test/matching.spec.ts
@@ -1,0 +1,133 @@
+import {
+  normalizePhone,
+  phoneMatches,
+  nameMatches,
+} from '../src/q10/matching';
+
+describe('normalizePhone', () => {
+  it('strips non-digits from a Guatemalan-formatted number', () => {
+    expect(normalizePhone('+502 5555-1234')).toBe('50255551234');
+  });
+
+  it('drops leading zero on local-format short numbers', () => {
+    expect(normalizePhone('0445551234')).toBe('445551234');
+  });
+
+  it('returns empty string for empty input', () => {
+    expect(normalizePhone('')).toBe('');
+  });
+
+  it('returns empty string for null / undefined', () => {
+    expect(normalizePhone(null)).toBe('');
+    expect(normalizePhone(undefined)).toBe('');
+  });
+
+  it('keeps leading zero on numbers longer than 11 digits (likely intl)', () => {
+    // 12-digit string starting with 0 should not have the 0 stripped,
+    // to avoid mangling something that isn't really local format.
+    expect(normalizePhone('012345678901')).toBe('012345678901');
+  });
+});
+
+describe('phoneMatches', () => {
+  it('returns true for exact match after normalization', () => {
+    expect(phoneMatches('+502 5555-1234', '50255551234')).toBe(true);
+  });
+
+  it('matches when one number is prefixed with a country code', () => {
+    expect(phoneMatches('+502 5555 1234', '55551234')).toBe(true);
+    expect(phoneMatches('55551234', '+502 5555 1234')).toBe(true);
+  });
+
+  it('matches on last-8-digits fallback when prefixes differ', () => {
+    // Different country+area code, but the last 8 digits line up — this
+    // handles the "+1 305 5555-1234" vs "+502 5555-1234" ambiguity.
+    expect(phoneMatches('13055551234', '50255551234')).toBe(true);
+  });
+
+  it('returns false for empty or null input on either side', () => {
+    expect(phoneMatches('', '50255551234')).toBe(false);
+    expect(phoneMatches('50255551234', '')).toBe(false);
+    expect(phoneMatches(null, '50255551234')).toBe(false);
+    expect(phoneMatches('50255551234', null)).toBe(false);
+    expect(phoneMatches(undefined, undefined)).toBe(false);
+  });
+
+  it('returns false when numbers are clearly different', () => {
+    expect(phoneMatches('50255551234', '50299998888')).toBe(false);
+  });
+
+  it('returns false when both normalized numbers are < 8 digits and differ', () => {
+    // Too short to trigger the last-8 fallback, and no endsWith relationship.
+    expect(phoneMatches('1234567', '7654321')).toBe(false);
+  });
+});
+
+describe('nameMatches', () => {
+  it('is accent-insensitive (María matches maria)', () => {
+    expect(nameMatches({ Nombres: 'María' }, 'maria')).toBe(true);
+  });
+
+  it('matches partial words (Mari matches María López)', () => {
+    expect(
+      nameMatches(
+        { Nombres: 'María Fernanda', Apellidos: 'López' },
+        'Mari',
+      ),
+    ).toBe(true);
+  });
+
+  it('is word-order-independent (Lopez Maria matches Maria Lopez)', () => {
+    expect(
+      nameMatches(
+        { Nombres: 'María', Apellidos: 'López' },
+        'Lopez Maria',
+      ),
+    ).toBe(true);
+  });
+
+  it('returns false when search is empty', () => {
+    expect(nameMatches({ Nombres: 'María' }, '')).toBe(false);
+  });
+
+  it('assembles the full name from Primer_nombre + Primer_apellido', () => {
+    expect(
+      nameMatches(
+        {
+          Primer_nombre: 'Carlos',
+          Segundo_nombre: 'Alberto',
+          Primer_apellido: 'García',
+          Segundo_apellido: 'Morales',
+        },
+        'Carlos Garcia',
+      ),
+    ).toBe(true);
+  });
+
+  it('returns false when the record has no name fields at all', () => {
+    expect(nameMatches({}, 'Maria')).toBe(false);
+  });
+
+  it('returns false when search words are absent from the record name', () => {
+    expect(
+      nameMatches(
+        { Nombres: 'María', Apellidos: 'López' },
+        'Roberto Estrada',
+      ),
+    ).toBe(false);
+  });
+
+  it('matches Nombre_completo field', () => {
+    expect(
+      nameMatches(
+        { Nombre_completo: 'Ana Lucía Hernández Paz' },
+        'ana hernandez',
+      ),
+    ).toBe(true);
+  });
+
+  it('matches when full name is wholly contained in the search', () => {
+    // fullName.includes(search) branch — record name is shorter than search.
+    expect(nameMatches({ Nombre: 'María' }, 'María del Carmen')).toBe(true);
+  });
+});


### PR DESCRIPTION
Two self-contained improvements borrowed from the Q10 WhatsApp extension.

## 1. Shared phone/name matching library

Ports the matching logic from `q10-whatsapp-plugin/background/service-worker.js` into `src/q10/matching.ts`:

- `normalizePhone(raw)` — strips non-digits, removes leading zero for local-format numbers
- `phoneMatches(a, b)` — exact, endsWith (country-code variance), last-8-digits fallback
- `nameMatches(record, search)` — NFD accent stripping, word-order-independent fuzzy match, multi-field assembly (`Primer_nombre` + `Segundo_nombre` + `Primer_apellido` + ...)

This becomes the single source of truth for both future search features in the dashboard (drill-down) and for the plugin when we consolidate it.

## 2. `/api/q10/catalogs` expansion

The plugin already fetches `mediospublicitarios` and `medioscontacto` because the "create oportunidad" flow needs them. Our catalogs endpoint now includes both, with `{ Estado: true }` filter to match the plugin.

- `Q10PublicController.catalogs()` returns `{ programas, periodos, sedes, mediospublicitarios, medioscontacto }`
- `src/q10/mock/mock-data.ts` adds 5 `mediospublicitarios` (Facebook Ads, Google Ads, Referido, Volante, Página web) and 5 `medioscontacto` (WhatsApp, Teléfono, Email, Visita sede, Formulario web), wired into `DATASETS`

## 3. Jest config tweak

Broadened `testRegex` from `.e2e-spec\.ts$` to `\.(e2e-)?spec\.ts$` so unit specs (`*.spec.ts`) run alongside e2e specs. Cleaner than renaming unit files.

## Test plan

- [x] `npm run build` clean
- [x] `npm test` — 52 tests passing (29 existing + 20 matching unit + 3 catalogs e2e)
- [ ] Verify `/api/q10/catalogs` in prod returns all 5 keys (may require Q10 plan support for `mediospublicitarios` / `medioscontacto`)

https://claude.ai/code/session_01GJarYvsaJrh1SZPznRsiDo