### PR TITLE
feat(dashboard): multi-tab dashboard (Académico/Financiero/Comercial) + field mapping fix

### DIFF
--- a/public/dashboard/dashboard.css
+++ b/public/dashboard/dashboard.css
@@ -179,6 +179,45 @@ body {
 }
 .user-chip__logout:hover { background: var(--gold-light); }
 
+.tabs {
+  display: flex;
+  gap: 0;
+  padding: 0 2rem;
+  background: var(--white);
+  border-bottom: 1px solid var(--border);
+  overflow-x: auto;
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  box-shadow: 0 1px 0 var(--border);
+}
+.tab {
+  padding: 1rem 1.3rem;
+  border: none;
+  background: transparent;
+  font-family: inherit;
+  font-size: 0.92rem;
+  font-weight: 500;
+  color: var(--gray-text);
+  cursor: pointer;
+  border-bottom: 3px solid transparent;
+  transition: color 120ms, border-color 120ms, background-color 120ms;
+  white-space: nowrap;
+}
+.tab:hover { color: var(--navy); background: var(--cream); }
+.tab.active {
+  color: var(--navy);
+  border-bottom-color: var(--gold);
+  font-weight: 700;
+}
+
+.tab-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+.tab-panel.hidden { display: none; }
+
 .app-main {
   flex: 1;
   padding: 1.75rem 2rem 3rem;

--- a/public/dashboard/dashboard.js
+++ b/public/dashboard/dashboard.js
@@ -254,7 +254,7 @@ function renderKpis(k) {
   }
   cards.push({ label: 'Ingresos del período', value: currency(k.revenueInRange), hint: `${state.rangeDays} días`, variant: 'success' });
   cards.push({ label: 'Deuda pendiente', value: currency(k.outstandingDebt), hint: `${k.ordersPending} cuotas abiertas`, variant: k.outstandingDebt > 0 ? 'danger' : '' });
-  cards.push({ label: 'Alumnos con pago', value: k.paidStudents, hint: `de ${k.totalStudents} matrículas` });
+  cards.push({ label: 'Alumnos con pago', value: k.studentsWithPaymentThisPeriod, hint: `de ${k.totalStudents} matrículas` });
 
   el('kpiGrid').innerHTML = cards
     .map((c) => {

--- a/public/dashboard/dashboard.js
+++ b/public/dashboard/dashboard.js
@@ -145,7 +145,7 @@ function setFreshness(msg) {
 function render(data) {
   renderPartialBanner(data);
   renderKpis(data.kpis);
-  renderFunnel(data.funnel);
+  renderFunnel(data.funnel, data.degraded);
   renderRevenueChart(data.charts.revenueByDay);
   renderStudentsChart(data.charts.newStudentsByDay);
   renderProgramsChart(data.distributions.studentsByProgram);
@@ -167,6 +167,7 @@ function renderPartialBanner(data) {
 }
 
 function currency(n) {
+  // GTQ symbol happens to be "Q" — matches the Spanish-speaking institution context.
   return new Intl.NumberFormat('es-GT', {
     style: 'currency',
     currency: 'GTQ',
@@ -175,16 +176,25 @@ function currency(n) {
 }
 
 function renderKpis(k) {
-  const cards = [
-    { label: 'Estudiantes activos', value: k.activeStudents, hint: `${k.totalStudents} totales`, accent: true },
-    { label: 'Nuevos en el rango', value: k.newStudentsInRange, hint: `${state.rangeDays} días` },
-    { label: 'Oportunidades abiertas', value: k.oppsOpen, hint: `${k.oppsWon} ganadas · ${k.oppsLost} perdidas` },
-    { label: 'Tasa de conversión', value: `${k.conversionRate}%`, hint: 'ganadas / totales', variant: k.conversionRate >= 30 ? 'success' : '' },
-    { label: 'Ingresos del período', value: currency(k.revenueInRange), hint: `${state.rangeDays} días`, variant: 'success' },
-    { label: 'Deuda pendiente', value: currency(k.outstandingDebt), hint: `${k.overduePending} vencidas`, variant: k.overduePending > 0 ? 'danger' : '' },
-    { label: 'Órdenes pendientes', value: k.ordersPending, hint: 'sin pago registrado' },
-    { label: 'Negocios activos', value: k.activeDeals, hint: 'en el pipeline' },
-  ];
+  // Build the KPI card list, skipping ones whose value is explicitly null
+  // (backend uses null to signal "this KPI isn't reliable on this plan").
+  const cards = [];
+  cards.push({ label: 'Estudiantes activos', value: k.activeStudents, hint: `${k.totalStudents} matriculados`, accent: true });
+  cards.push({ label: 'Nuevos en el rango', value: k.newStudentsInRange, hint: `${state.rangeDays} días` });
+  cards.push({ label: 'Nuevos este período', value: k.newEnrollmentsThisPeriod, hint: 'vs. renovados' });
+  cards.push({ label: 'Contactos en CRM', value: k.totalContacts, hint: 'leads registrados' });
+  cards.push({ label: 'Oportunidades', value: k.oppsTotal, hint: 'total en el CRM' });
+  if (k.conversionRate != null) {
+    cards.push({
+      label: 'Tasa de conversión',
+      value: `${k.conversionRate}%`,
+      hint: 'ganadas / totales',
+      variant: k.conversionRate >= 30 ? 'success' : '',
+    });
+  }
+  cards.push({ label: 'Ingresos del período', value: currency(k.revenueInRange), hint: `${state.rangeDays} días`, variant: 'success' });
+  cards.push({ label: 'Deuda pendiente', value: currency(k.outstandingDebt), hint: `${k.ordersPending} cuotas abiertas`, variant: k.outstandingDebt > 0 ? 'danger' : '' });
+  cards.push({ label: 'Alumnos con pago', value: k.paidStudents, hint: `de ${k.totalStudents} matrículas` });
 
   el('kpiGrid').innerHTML = cards
     .map((c) => {
@@ -200,20 +210,37 @@ function renderKpis(k) {
     .join('');
 }
 
-function renderFunnel(f) {
+function renderFunnel(f, degraded) {
+  // When the CRM is underused (few opportunities vs many enrollments) the
+  // ratio-as-percentage is misleading. Backend flags that via `degraded` and
+  // we show the absolute numbers only.
+  const hidePercent = !!(degraded && degraded.conversionRate);
   const rate = (num, den) => (den > 0 ? Math.round((num / den) * 100) : 0);
   const stages = [
-    { label: 'Oportunidades', value: f.opportunities, sub: 'Total en CRM' },
-    { label: 'Matrículas', value: f.enrollments, sub: `${rate(f.enrollments, f.opportunities)}% del total` },
-    { label: 'Pagadas', value: f.paidEnrollments, sub: `${rate(f.paidEnrollments, f.enrollments)}% del total`, paid: true },
+    {
+      label: 'Oportunidades',
+      value: f.opportunities,
+      sub: 'Total en CRM',
+    },
+    {
+      label: 'Matrículas',
+      value: f.enrollments,
+      sub: hidePercent ? 'Matriculados en el período' : `${rate(f.enrollments, f.opportunities)}% del total`,
+    },
+    {
+      label: 'Con pago',
+      value: f.paidEnrollments,
+      sub: f.enrollments > 0 ? `${rate(f.paidEnrollments, f.enrollments)}% de matrículas` : '—',
+      paid: true,
+    },
   ];
   el('funnel').innerHTML = stages
     .map(
       (s) => `
       <div class="funnel__stage ${s.paid ? 'funnel__stage--paid' : ''}">
-        <div class="funnel__label">${s.label}</div>
-        <div class="funnel__value">${s.value}</div>
-        <div class="funnel__rate">${s.sub}</div>
+        <div class="funnel__label">${escapeHtml(s.label)}</div>
+        <div class="funnel__value">${escapeHtml(String(s.value))}</div>
+        <div class="funnel__rate">${escapeHtml(s.sub)}</div>
       </div>`,
     )
     .join('');

--- a/public/dashboard/dashboard.js
+++ b/public/dashboard/dashboard.js
@@ -8,6 +8,10 @@ const state = {
   rangeDays: 30,
   charts: {},
   timer: null,
+  activeTab: 'overview',
+  // Cache per tab so switching back and forth doesn't re-hit /api. Invalidated
+  // by refreshBtn or the 60s auto-timer.
+  loaded: { overview: false, academic: false, financial: false, commercial: false },
 };
 
 // ─── Elements ───
@@ -23,11 +27,45 @@ document.addEventListener('DOMContentLoaded', async () => {
 function bindEvents() {
   el('loginForm').addEventListener('submit', onLogin);
   el('logoutBtn').addEventListener('click', onLogout);
-  el('refreshBtn').addEventListener('click', () => loadOverview(true));
+  el('refreshBtn').addEventListener('click', () => refreshActiveTab(true));
   el('rangeSelect').addEventListener('change', (e) => {
     state.rangeDays = Number(e.target.value);
-    loadOverview(false);
+    // Range only affects Overview; other tabs ignore it.
+    state.loaded.overview = false;
+    if (state.activeTab === 'overview') loadOverview(false);
   });
+
+  // Tab navigation
+  document.querySelectorAll('.tab').forEach((btn) => {
+    btn.addEventListener('click', () => switchTab(btn.dataset.tab));
+  });
+}
+
+function switchTab(name) {
+  if (state.activeTab === name) return;
+  state.activeTab = name;
+  document.querySelectorAll('.tab').forEach((t) => {
+    t.classList.toggle('active', t.dataset.tab === name);
+    t.setAttribute('aria-selected', t.dataset.tab === name ? 'true' : 'false');
+  });
+  document.querySelectorAll('.tab-panel').forEach((p) => {
+    p.classList.toggle('hidden', p.id !== `tab-${name}`);
+  });
+  // Range picker is only meaningful on the Overview tab.
+  el('rangeSelect').style.display = name === 'overview' ? '' : 'none';
+  // Load lazily the first time the tab is opened.
+  if (!state.loaded[name]) loadTab(name, false);
+}
+
+function refreshActiveTab(force) {
+  loadTab(state.activeTab, force);
+}
+
+function loadTab(name, force) {
+  if (name === 'overview') return loadOverview(force);
+  if (name === 'academic') return loadAcademic(force);
+  if (name === 'financial') return loadFinancial(force);
+  if (name === 'commercial') return loadCommercial(force);
 }
 
 // ─── Auth flow ───
@@ -104,12 +142,33 @@ function showApp() {
 
 function startAutoRefresh() {
   stopAutoRefresh();
-  state.timer = setInterval(() => loadOverview(false), AUTO_REFRESH_MS);
+  // Auto-refresh only the active tab — don't burn Q10 quota on tabs the
+  // operator isn't even looking at.
+  state.timer = setInterval(() => refreshActiveTab(false), AUTO_REFRESH_MS);
 }
 
 function stopAutoRefresh() {
   if (state.timer) clearInterval(state.timer);
   state.timer = null;
+}
+
+// ─── Common fetch helper ───
+async function fetchTab(path, force) {
+  setFreshness('Cargando datos del ERP…');
+  try {
+    if (force) {
+      await fetch(`${API}/dashboard/refresh`, { method: 'POST', credentials: 'include' });
+    }
+    const resp = await fetch(path, { credentials: 'include' });
+    if (resp.status === 401) { state.user = null; showLogin(); return null; }
+    if (!resp.ok) throw new Error('Error al cargar datos');
+    const data = await resp.json();
+    setFreshness(`Actualizado a las ${new Date().toLocaleTimeString('es')}`);
+    return data;
+  } catch (err) {
+    setFreshness(`⚠ ${err.message || 'Error inesperado'}`);
+    return null;
+  }
 }
 
 // ─── Data loading ───
@@ -131,6 +190,7 @@ async function loadOverview(force) {
     if (!resp.ok) throw new Error('Error al cargar datos');
     const data = await resp.json();
     render(data);
+    state.loaded.overview = true;
     setFreshness(`Actualizado a las ${new Date().toLocaleTimeString('es')}`);
   } catch (err) {
     setFreshness(`⚠ ${err.message || 'Error inesperado'}`);
@@ -395,4 +455,245 @@ function escapeHtml(v) {
   return String(v ?? '').replace(/[&<>"']/g, (c) => ({
     '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;',
   }[c]));
+}
+
+// Render a simple `key: count` distribution as a horizontal bar chart.
+function renderDistributionChart(canvasId, dist, colour = '#000E38') {
+  destroyChart(canvasId);
+  const ctx = el(canvasId).getContext('2d');
+  const entries = Object.entries(dist).sort((a, b) => b[1] - a[1]);
+  state.charts[canvasId] = new Chart(ctx, {
+    type: 'bar',
+    data: {
+      labels: entries.map(([k]) => k),
+      datasets: [{
+        data: entries.map(([, v]) => v),
+        backgroundColor: colour,
+        borderRadius: 6,
+      }],
+    },
+    options: {
+      indexAxis: 'y',
+      responsive: true,
+      plugins: { legend: { display: false } },
+      scales: { x: { beginAtZero: true, ticks: { stepSize: 1 } } },
+    },
+  });
+}
+
+function renderDonut(canvasId, dist, palette) {
+  destroyChart(canvasId);
+  const ctx = el(canvasId).getContext('2d');
+  const labels = Object.keys(dist);
+  const values = Object.values(dist);
+  const colors = palette ?? ['#000E38', '#DCAF63', '#1a2456', '#EBC584', '#606060', '#FFF8EF'];
+  state.charts[canvasId] = new Chart(ctx, {
+    type: 'doughnut',
+    data: { labels, datasets: [{ data: values, backgroundColor: colors }] },
+    options: { responsive: true, plugins: { legend: { position: 'bottom' } } },
+  });
+}
+
+function renderMonthlyLine(canvasId, series, colour, isMoney) {
+  destroyChart(canvasId);
+  const ctx = el(canvasId).getContext('2d');
+  state.charts[canvasId] = new Chart(ctx, {
+    type: 'line',
+    data: {
+      labels: series.map((s) => s.month),
+      datasets: [{
+        data: series.map((s) => s.value),
+        borderColor: colour,
+        backgroundColor: colour + '26',
+        tension: 0.3,
+        fill: true,
+        pointRadius: 3,
+      }],
+    },
+    options: {
+      responsive: true,
+      plugins: { legend: { display: false } },
+      scales: {
+        y: {
+          beginAtZero: true,
+          ticks: isMoney ? { callback: (v) => currency(v) } : { stepSize: 1 },
+        },
+      },
+    },
+  });
+}
+
+// ═════════════════ ACADEMIC TAB ═════════════════
+async function loadAcademic(force) {
+  const data = await fetchTab(`${API}/dashboard/academic`, force);
+  if (!data) return;
+  state.loaded.academic = true;
+
+  const s = data.summary || {};
+  el('academicKpis').innerHTML = [
+    { label: 'Estudiantes matriculados', value: s.totalStudents, hint: s.currentPeriod || '—', accent: true },
+    { label: 'Docentes activos', value: s.totalTeachers, hint: 'en la planta' },
+    { label: 'Edad promedio', value: s.avgAge != null ? `${s.avgAge} años` : '—', hint: 'estudiantes activos' },
+    { label: 'Retención', value: data.retention.retentionRate != null ? `${data.retention.retentionRate}%` : '—', hint: `${data.retention.retained} de ${data.retention.previousTotal}` },
+  ].map(kpiCard).join('');
+
+  // Retention funnel
+  const r = data.retention;
+  el('retention').innerHTML = [
+    { label: 'Período anterior', value: r.previousTotal, sub: r.previousPeriod || '—' },
+    { label: 'Retenidos', value: r.retained, sub: r.retentionRate != null ? `${r.retentionRate}% retención` : '—', paid: true },
+    { label: 'Churn', value: r.churned, sub: r.churnRate != null ? `${r.churnRate}% salieron` : '—' },
+    { label: 'Nuevos', value: r.newcomers, sub: 'entraron ahora' },
+  ].map(funnelStage).join('');
+
+  // Charts
+  renderDistributionChart('jornadaChart', data.distributions.byJornada, '#DCAF63');
+  renderDistributionChart('nivelChart', data.distributions.byNivel, '#000E38');
+  renderDonut('genderChart', data.distributions.byGender);
+  renderDistributionChart('ageChart', data.distributions.byAge, '#1a2456');
+
+  // Teachers table
+  const tbody = document.querySelector('#teachersTable tbody');
+  if (!data.teachers.length) {
+    tbody.innerHTML = '<tr><td colspan="4" style="text-align:center;color:var(--gray-text)">Sin docentes</td></tr>';
+  } else {
+    tbody.innerHTML = data.teachers.map((t) => `
+      <tr>
+        <td>${escapeHtml([t.Nombres, t.Apellidos].filter(Boolean).join(' ') || '—')}</td>
+        <td>${escapeHtml(t.Email || '—')}</td>
+        <td>${escapeHtml(t.Celular || '—')}</td>
+        <td>${escapeHtml(t.Genero || '—')}</td>
+      </tr>`).join('');
+  }
+
+  applyPartialBanner(data);
+}
+
+// ═════════════════ FINANCIAL TAB ═════════════════
+async function loadFinancial(force) {
+  const data = await fetchTab(`${API}/dashboard/financial?months=12`, force);
+  if (!data) return;
+  state.loaded.financial = true;
+
+  const s = data.summary || {};
+  el('financialKpis').innerHTML = [
+    { label: 'Ingresos (12m)', value: currency(s.totalRevenue), hint: `${s.payingStudents} alumnos pagantes`, accent: true, variant: 'success' },
+    { label: 'Ticket promedio', value: currency(s.avgTicket), hint: 'por pagante (12m)' },
+    { label: 'LTV aproximado', value: currency(s.ltvApprox), hint: `máx. ${currency(s.maxPaid)}` },
+    { label: 'Deuda pendiente', value: currency(s.outstandingDebt), hint: `${s.activeWithDebt || 0} alumnos activos con saldo`, variant: s.outstandingDebt > 0 ? 'danger' : '' },
+    { label: 'Inadimplencia', value: s.inadimplenciaRate != null ? `${s.inadimplenciaRate}%` : '—', hint: 'de alumnos activos' },
+    { label: 'Avance del período', value: s.projectionRate != null ? `${s.projectionRate}%` : '—', hint: 'pagado / proyectado' },
+  ].map(kpiCard).join('');
+
+  renderMonthlyLine('mrrChart', data.charts.revenueByMonth, '#DCAF63', true);
+  renderDistributionChart('revenueByProgramChart', data.charts.revenueByConcept, '#DCAF63');
+
+  // Top debtors table
+  const debt = document.querySelector('#debtorsTable tbody');
+  if (!data.tables.topDebtors.length) {
+    debt.innerHTML = '<tr><td colspan="6" style="text-align:center;color:var(--gray-text)">Sin deudas registradas</td></tr>';
+  } else {
+    debt.innerHTML = data.tables.topDebtors.map((d) => `
+      <tr>
+        <td>${escapeHtml(d.estudiante)}</td>
+        <td>${escapeHtml(d.concepto || '—')}</td>
+        <td>${escapeHtml(d.periodo || '—')}</td>
+        <td>${currency(d.total)}</td>
+        <td>${currency(d.pagado)}</td>
+        <td><strong>${currency(d.saldo)}</strong></td>
+      </tr>`).join('');
+  }
+
+  // Recent payments
+  const pay = document.querySelector('#recentPaymentsTable tbody');
+  if (!data.tables.recentPayments.length) {
+    pay.innerHTML = '<tr><td colspan="4" style="text-align:center;color:var(--gray-text)">Sin pagos</td></tr>';
+  } else {
+    pay.innerHTML = data.tables.recentPayments.map((p) => `
+      <tr>
+        <td>${escapeHtml(p.fecha || '—')}</td>
+        <td>${escapeHtml(p.estudiante || '—')}</td>
+        <td>${escapeHtml(p.recibo || '—')}</td>
+        <td>${currency(p.valor)}</td>
+      </tr>`).join('');
+  }
+
+  applyPartialBanner(data);
+}
+
+// ═════════════════ COMMERCIAL TAB ═════════════════
+async function loadCommercial(force) {
+  const data = await fetchTab(`${API}/dashboard/commercial`, force);
+  if (!data) return;
+  state.loaded.commercial = true;
+
+  const s = data.summary || {};
+  el('commercialKpis').innerHTML = [
+    { label: 'Oportunidades totales', value: s.totalOpportunities, hint: 'en el CRM', accent: true },
+    { label: 'Contactos', value: s.totalContacts, hint: 'leads en base' },
+    { label: 'Ganadas', value: s.won, hint: 'matriculadas', variant: 'success' },
+    { label: 'Perdidas', value: s.lost, hint: 'no cerradas', variant: s.lost > 0 ? 'danger' : '' },
+    { label: 'En progreso', value: s.inProgress, hint: 'negociando' },
+    { label: 'Tasa de conversión', value: s.conversionRate != null ? `${s.conversionRate}%` : '—', hint: 'ganadas / total' },
+    { label: 'Indicaciones', value: s.referralCount, hint: s.referralRate != null ? `${s.referralRate}% del total` : '—' },
+    { label: 'Asesores activos', value: s.advisorCount, hint: 'con oportunidades' },
+  ].map(kpiCard).join('');
+
+  renderMonthlyLine('leadsChart', data.charts.leadsByMonth, '#000E38', false);
+  renderDonut('stateChart', data.charts.byState);
+  renderDistributionChart('originChart', data.charts.byOrigin, '#DCAF63');
+
+  // Advisors
+  const adv = document.querySelector('#advisorsTable tbody');
+  adv.innerHTML = data.tables.advisors.length
+    ? data.tables.advisors.map((a) => `<tr><td>${escapeHtml(a.nombre)}</td><td>${a.total}</td></tr>`).join('')
+    : '<tr><td colspan="2" style="text-align:center;color:var(--gray-text)">Sin asesores</td></tr>';
+
+  // Municipios
+  const mun = document.querySelector('#municipiosTable tbody');
+  mun.innerHTML = data.tables.topMunicipios.length
+    ? data.tables.topMunicipios.map((m) => `<tr><td>${escapeHtml(m.municipio)}</td><td>${m.total}</td></tr>`).join('')
+    : '<tr><td colspan="2" style="text-align:center;color:var(--gray-text)">Sin datos geográficos</td></tr>';
+
+  // Recent opps
+  const opps = document.querySelector('#oppsTable tbody');
+  opps.innerHTML = data.tables.recentOpps.length
+    ? data.tables.recentOpps.map((o) => `
+        <tr>
+          <td>${escapeHtml(o.fecha || '—')}</td>
+          <td>${escapeHtml(o.nombre || '—')}</td>
+          <td>${escapeHtml(o.origen || '—')}</td>
+          <td>${escapeHtml(o.canal || '—')}</td>
+          <td><span class="badge">${escapeHtml(o.estado)}</span></td>
+          <td>${escapeHtml(o.asesor || '—')}</td>
+        </tr>`).join('')
+    : '<tr><td colspan="6" style="text-align:center;color:var(--gray-text)">Sin oportunidades registradas</td></tr>';
+
+  applyPartialBanner(data);
+}
+
+// ─── Shared UI helpers for the new tabs ───
+function kpiCard(c) {
+  const variantClass = c.variant ? `kpi--${c.variant}` : '';
+  const accentClass = c.accent ? 'kpi--accent' : '';
+  return `
+    <div class="kpi ${accentClass} ${variantClass}">
+      <div class="kpi__label">${escapeHtml(c.label)}</div>
+      <div class="kpi__value">${escapeHtml(String(c.value))}</div>
+      <div class="kpi__hint">${escapeHtml(c.hint ?? '')}</div>
+    </div>`;
+}
+
+function funnelStage(s) {
+  return `
+    <div class="funnel__stage ${s.paid ? 'funnel__stage--paid' : ''}">
+      <div class="funnel__label">${escapeHtml(s.label)}</div>
+      <div class="funnel__value">${escapeHtml(String(s.value))}</div>
+      <div class="funnel__rate">${escapeHtml(s.sub ?? '')}</div>
+    </div>`;
+}
+
+function applyPartialBanner(data) {
+  // Each tab can toggle the banner; when the active tab has errors, show them.
+  renderPartialBanner(data);
 }

--- a/public/dashboard/index.html
+++ b/public/dashboard/index.html
@@ -77,6 +77,13 @@
       </div>
     </header>
 
+    <nav class="tabs" id="tabs" role="tablist">
+      <button class="tab active" data-tab="overview" role="tab" aria-selected="true">📊 Visión general</button>
+      <button class="tab" data-tab="academic" role="tab">🎓 Académico</button>
+      <button class="tab" data-tab="financial" role="tab">💰 Financiero</button>
+      <button class="tab" data-tab="commercial" role="tab">🎯 Comercial / CRM</button>
+    </nav>
+
     <main class="app-main">
       <div class="freshness" id="freshness">Cargando…</div>
 
@@ -85,60 +92,177 @@
         <span id="partialBannerDetail"></span>
       </div>
 
-      <!-- KPIs -->
-      <section class="kpi-grid" id="kpiGrid"></section>
+      <!-- ───────────── TAB: Overview ───────────── -->
+      <div class="tab-panel" id="tab-overview" role="tabpanel">
+        <section class="kpi-grid" id="kpiGrid"></section>
 
-      <!-- Funnel -->
-      <section class="card">
-        <h2 class="card__title">Funnel de conversión</h2>
-        <div class="funnel" id="funnel"></div>
-      </section>
+        <section class="card">
+          <h2 class="card__title">Funnel de conversión</h2>
+          <div class="funnel" id="funnel"></div>
+        </section>
 
-      <!-- Charts -->
-      <section class="chart-grid">
-        <div class="card">
-          <h2 class="card__title">Ingresos por día</h2>
-          <canvas id="revenueChart" height="120"></canvas>
-        </div>
-        <div class="card">
-          <h2 class="card__title">Nuevos estudiantes</h2>
-          <canvas id="studentsChart" height="120"></canvas>
-        </div>
-      </section>
+        <section class="chart-grid">
+          <div class="card">
+            <h2 class="card__title">Ingresos por día</h2>
+            <canvas id="revenueChart" height="120"></canvas>
+          </div>
+          <div class="card">
+            <h2 class="card__title">Nuevos estudiantes</h2>
+            <canvas id="studentsChart" height="120"></canvas>
+          </div>
+        </section>
 
-      <!-- Distributions -->
-      <section class="chart-grid">
-        <div class="card">
-          <h2 class="card__title">Estudiantes por programa</h2>
-          <canvas id="programsChart" height="140"></canvas>
-        </div>
-        <div class="card">
-          <h2 class="card__title">Origen de oportunidades</h2>
-          <canvas id="originsChart" height="140"></canvas>
-        </div>
-      </section>
+        <section class="chart-grid">
+          <div class="card">
+            <h2 class="card__title">Últimos estudiantes</h2>
+            <div class="table-wrapper">
+              <table class="data-table" id="recentStudents">
+                <thead><tr><th>Nombre</th><th>Programa</th><th>Estado</th></tr></thead>
+                <tbody></tbody>
+              </table>
+            </div>
+          </div>
+          <div class="card">
+            <h2 class="card__title">Pagos pendientes</h2>
+            <div class="table-wrapper">
+              <table class="data-table" id="pendingPayments">
+                <thead><tr><th>Estudiante</th><th>Concepto</th><th>Período</th><th>Valor</th></tr></thead>
+                <tbody></tbody>
+              </table>
+            </div>
+          </div>
+        </section>
+      </div>
 
-      <!-- Tables -->
-      <section class="chart-grid">
-        <div class="card">
-          <h2 class="card__title">Últimos estudiantes</h2>
+      <!-- ───────────── TAB: Academic ───────────── -->
+      <div class="tab-panel hidden" id="tab-academic" role="tabpanel">
+        <section class="kpi-grid" id="academicKpis"></section>
+
+        <section class="card">
+          <h2 class="card__title">Retención del período</h2>
+          <div class="funnel" id="retention"></div>
+        </section>
+
+        <section class="chart-grid">
+          <div class="card">
+            <h2 class="card__title">Por jornada</h2>
+            <canvas id="jornadaChart" height="140"></canvas>
+          </div>
+          <div class="card">
+            <h2 class="card__title">Por nivel CEFR</h2>
+            <canvas id="nivelChart" height="140"></canvas>
+          </div>
+        </section>
+
+        <section class="chart-grid">
+          <div class="card">
+            <h2 class="card__title">Por género</h2>
+            <canvas id="genderChart" height="140"></canvas>
+          </div>
+          <div class="card">
+            <h2 class="card__title">Por rango de edad</h2>
+            <canvas id="ageChart" height="140"></canvas>
+          </div>
+        </section>
+
+        <section class="card">
+          <h2 class="card__title">Docentes</h2>
           <div class="table-wrapper">
-            <table class="data-table" id="recentStudents">
-              <thead><tr><th>Nombre</th><th>Programa</th><th>Estado</th></tr></thead>
+            <table class="data-table" id="teachersTable">
+              <thead><tr><th>Nombre</th><th>Email</th><th>Celular</th><th>Género</th></tr></thead>
               <tbody></tbody>
             </table>
           </div>
-        </div>
-        <div class="card">
-          <h2 class="card__title">Pagos pendientes</h2>
+        </section>
+      </div>
+
+      <!-- ───────────── TAB: Financial ───────────── -->
+      <div class="tab-panel hidden" id="tab-financial" role="tabpanel">
+        <section class="kpi-grid" id="financialKpis"></section>
+
+        <section class="card">
+          <h2 class="card__title">Ingresos mensuales (últimos 12 meses)</h2>
+          <canvas id="mrrChart" height="100"></canvas>
+        </section>
+
+        <section class="chart-grid">
+          <div class="card">
+            <h2 class="card__title">Ingresos por programa</h2>
+            <canvas id="revenueByProgramChart" height="140"></canvas>
+          </div>
+          <div class="card">
+            <h2 class="card__title">Últimos pagos</h2>
+            <div class="table-wrapper">
+              <table class="data-table" id="recentPaymentsTable">
+                <thead><tr><th>Fecha</th><th>Estudiante</th><th>Recibo</th><th>Valor</th></tr></thead>
+                <tbody></tbody>
+              </table>
+            </div>
+          </div>
+        </section>
+
+        <section class="card">
+          <h2 class="card__title">Top deudores (mayor saldo)</h2>
           <div class="table-wrapper">
-            <table class="data-table" id="pendingPayments">
-              <thead><tr><th>Estudiante</th><th>Concepto</th><th>Vencimiento</th><th>Valor</th></tr></thead>
+            <table class="data-table" id="debtorsTable">
+              <thead><tr><th>Estudiante</th><th>Concepto</th><th>Período</th><th>Total</th><th>Pagado</th><th>Saldo</th></tr></thead>
               <tbody></tbody>
             </table>
           </div>
-        </div>
-      </section>
+        </section>
+      </div>
+
+      <!-- ───────────── TAB: Commercial ───────────── -->
+      <div class="tab-panel hidden" id="tab-commercial" role="tabpanel">
+        <section class="kpi-grid" id="commercialKpis"></section>
+
+        <section class="card">
+          <h2 class="card__title">Nuevos leads por mes (últimos 12 meses)</h2>
+          <canvas id="leadsChart" height="100"></canvas>
+        </section>
+
+        <section class="chart-grid">
+          <div class="card">
+            <h2 class="card__title">Estado del funnel</h2>
+            <canvas id="stateChart" height="140"></canvas>
+          </div>
+          <div class="card">
+            <h2 class="card__title">Origen de los leads</h2>
+            <canvas id="originChart" height="140"></canvas>
+          </div>
+        </section>
+
+        <section class="chart-grid">
+          <div class="card">
+            <h2 class="card__title">Carga de trabajo por asesor</h2>
+            <div class="table-wrapper">
+              <table class="data-table" id="advisorsTable">
+                <thead><tr><th>Asesor</th><th>Oportunidades</th></tr></thead>
+                <tbody></tbody>
+              </table>
+            </div>
+          </div>
+          <div class="card">
+            <h2 class="card__title">Top municipios</h2>
+            <div class="table-wrapper">
+              <table class="data-table" id="municipiosTable">
+                <thead><tr><th>Municipio</th><th>Leads</th></tr></thead>
+                <tbody></tbody>
+              </table>
+            </div>
+          </div>
+        </section>
+
+        <section class="card">
+          <h2 class="card__title">Oportunidades recientes</h2>
+          <div class="table-wrapper">
+            <table class="data-table" id="oppsTable">
+              <thead><tr><th>Fecha</th><th>Nombre</th><th>Origen</th><th>Canal</th><th>Estado</th><th>Asesor</th></tr></thead>
+              <tbody></tbody>
+            </table>
+          </div>
+        </section>
+      </div>
 
       <footer class="app-footer">
         © <span id="year"></span> Genius Idiomas · <a href="/">Volver al sitio</a>

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { Module, Logger } from '@nestjs/common';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { APP_GUARD } from '@nestjs/core';
 import { ServeStaticModule } from '@nestjs/serve-static';
@@ -10,7 +10,10 @@ import { User } from './auth/user.entity';
 import { EmailModule } from './email/email.module';
 import { HealthController } from './health/health.controller';
 import { LeadsModule } from './leads/leads.module';
+import { TrackingEntryEntity } from './q10/tracking-entry.entity';
 import { Q10Module } from './q10/q10.module';
+
+const bootstrapLogger = new Logger('AppModule');
 
 @Module({
   imports: [
@@ -19,17 +22,32 @@ import { Q10Module } from './q10/q10.module';
     // 100 requests per minute per IP
     ThrottlerModule.forRoot([{ ttl: 60_000, limit: 100 }]),
 
-    // SQLite for users. File lives at DATABASE_PATH (mount a persistent
-    // volume at that path in production, otherwise users vanish on restart).
+    // SQLite for users + enrollment tracking. File lives at DATABASE_PATH —
+    // mount a persistent volume there in production, otherwise the entire
+    // store (admin user, in-flight enrollment IDs) vanishes on restart and
+    // breaks idempotency for retries (review feedback).
     TypeOrmModule.forRootAsync({
       imports: [ConfigModule],
       inject: [ConfigService],
-      useFactory: (cfg: ConfigService) => ({
-        type: 'better-sqlite3',
-        database: cfg.get<string>('DATABASE_PATH') ?? './data/genius.sqlite',
-        entities: [User],
-        synchronize: true,
-      }),
+      useFactory: (cfg: ConfigService) => {
+        const isProd = cfg.get<string>('NODE_ENV') === 'production';
+        // We keep `synchronize: true` for now — first deploy creates tables,
+        // and the schema is small. Migrations are tracked as a v2 follow-up;
+        // when we add them, flip this to `!isProd` and drop a migrations dir.
+        if (isProd) {
+          bootstrapLogger.warn(
+            'TypeORM synchronize=true in production: keeps schema in sync ' +
+            'with entities, but a destructive entity rename would drop data. ' +
+            'Plan to switch to migrations before non-additive schema changes.',
+          );
+        }
+        return {
+          type: 'better-sqlite3',
+          database: cfg.get<string>('DATABASE_PATH') ?? './data/genius.sqlite',
+          entities: [User, TrackingEntryEntity],
+          synchronize: true,
+        };
+      },
     }),
 
     ServeStaticModule.forRoot({

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,7 +5,47 @@ import { mkdirSync } from 'fs';
 import { dirname } from 'path';
 import { AppModule } from './app.module';
 
+/**
+ * Refuse to start in production with placeholder/missing security secrets.
+ * Catches the classic deploy mistake of leaving `.env.example` defaults in
+ * place (review #7 finding).
+ */
+function assertProductionEnv(): void {
+  if (process.env.NODE_ENV !== 'production') return;
+  const missing: string[] = [];
+  const placeholder: string[] = [];
+
+  const jwt = process.env.JWT_SECRET ?? '';
+  if (!jwt) missing.push('JWT_SECRET');
+  else if (jwt.length < 32 || jwt.startsWith('change-me')) placeholder.push('JWT_SECRET');
+
+  const adminPass = process.env.ADMIN_PASSWORD ?? '';
+  // ADMIN_PASSWORD is only consumed once (admin seed on first boot). After
+  // that the operator can remove it; we therefore only flag the placeholder
+  // value, not the absence.
+  if (adminPass && adminPass.startsWith('change-me')) placeholder.push('ADMIN_PASSWORD');
+
+  const origins = (process.env.ALLOWED_ORIGINS ?? '')
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+  if (origins.length === 0) missing.push('ALLOWED_ORIGINS');
+
+  if (missing.length || placeholder.length) {
+    const lines: string[] = [
+      'Refusing to start in production: insecure environment configuration.',
+    ];
+    if (missing.length) lines.push(`  Missing: ${missing.join(', ')}`);
+    if (placeholder.length) lines.push(`  Still set to placeholder values: ${placeholder.join(', ')}`);
+    lines.push('  Set the variables above (see .env.example) and redeploy.');
+    console.error(lines.join('\n'));
+    process.exit(1);
+  }
+}
+
 async function bootstrap() {
+  assertProductionEnv();
+
   // Make sure the SQLite data directory exists before TypeORM tries to open it.
   const dbPath = process.env.DATABASE_PATH ?? './data/genius.sqlite';
   mkdirSync(dirname(dbPath), { recursive: true });
@@ -14,17 +54,21 @@ async function bootstrap() {
 
   app.use(cookieParser());
 
-  const allowed =
-    (process.env.ALLOWED_ORIGINS ?? '')
-      .split(',')
-      .map((s) => s.trim())
-      .filter(Boolean);
+  const allowed = (process.env.ALLOWED_ORIGINS ?? '')
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+  const isProd = process.env.NODE_ENV === 'production';
 
   app.enableCors({
     origin: (origin, callback) => {
+      // Same-origin / server-to-server / curl: no Origin header → allow.
       if (!origin) return callback(null, true);
-      if (allowed.length === 0) return callback(null, true);
       if (allowed.includes(origin)) return callback(null, true);
+      // In dev with no allowlist set, accept any origin to keep the loop
+      // tight. In production `assertProductionEnv()` guarantees `allowed`
+      // is non-empty, so we never fall through to "allow everyone".
+      if (!isProd && allowed.length === 0) return callback(null, true);
       callback(new Error(`CORS: origin ${origin} not allowed`));
     },
     credentials: true,

--- a/src/q10/dashboard.controller.ts
+++ b/src/q10/dashboard.controller.ts
@@ -1,5 +1,8 @@
 import { Controller, Get, Post, Query, UseGuards } from '@nestjs/common';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { AcademicService } from './dashboard/academic.service';
+import { CommercialService } from './dashboard/commercial.service';
+import { FinancialService } from './dashboard/financial.service';
 import { DashboardService } from './dashboard.service';
 import { Q10ClientService } from './q10-client.service';
 
@@ -8,6 +11,9 @@ import { Q10ClientService } from './q10-client.service';
 export class DashboardController {
   constructor(
     private readonly dashboard: DashboardService,
+    private readonly academic: AcademicService,
+    private readonly financial: FinancialService,
+    private readonly commercial: CommercialService,
     private readonly q10: Q10ClientService,
   ) {}
 
@@ -15,6 +21,22 @@ export class DashboardController {
   overview(@Query('range') range?: string) {
     const days = Math.max(1, Math.min(365, Number(range ?? 30) || 30));
     return this.dashboard.overview(days);
+  }
+
+  @Get('academic')
+  academicView() {
+    return this.academic.academic();
+  }
+
+  @Get('financial')
+  financialView(@Query('months') months?: string) {
+    const n = Math.max(1, Math.min(60, Number(months ?? 12) || 12));
+    return this.financial.financial(n);
+  }
+
+  @Get('commercial')
+  commercialView() {
+    return this.commercial.commercial();
   }
 
   @Post('refresh')

--- a/src/q10/dashboard.service.ts
+++ b/src/q10/dashboard.service.ts
@@ -18,20 +18,31 @@ function parseDate(value: unknown): Date | null {
   return isNaN(d.getTime()) ? null : d;
 }
 
+/** Trim + treat literal "null" strings as empty (Q10 serialises nulls that way). */
+function cleanStr(v: unknown): string {
+  if (v == null) return '';
+  const s = String(v).trim();
+  return s === 'null' ? '' : s;
+}
+
+/** Q10 serialises booleans as the literal string "true"/"false" sometimes. */
 function isActivo(status: unknown): boolean {
   if (status === true) return true;
-  if (typeof status !== 'string') return false;
-  return status.toLowerCase().includes('activ');
+  const s = cleanStr(status).toLowerCase();
+  return s === 'true' || s.includes('activ');
 }
 
 function sum(list: Item[], field: string): number {
   return list.reduce((acc, x) => acc + (Number(x[field]) || 0), 0);
 }
 
-function groupCount<T extends Item>(list: T[], field: string): Record<string, number> {
+function groupCount<T extends Item>(
+  list: T[],
+  getter: (item: T) => unknown,
+): Record<string, number> {
   const out: Record<string, number> = {};
   for (const item of list) {
-    const key = String(item[field] ?? 'Sin especificar');
+    const key = cleanStr(getter(item)) || 'Sin especificar';
     out[key] = (out[key] ?? 0) + 1;
   }
   return out;
@@ -49,30 +60,24 @@ function currentlyActivePeriods(periodos: Item[]): Item[] {
   return current.length > 0 ? current : active;
 }
 
-/**
- * Extract the consecutive ID from a /periodos record. Q10 exposes it under
- * `Consecutivo` (the canonical field), and some endpoints surface it as
- * `Consecutivo_periodo` when the consecutive belongs to a nested resource.
- * `Codigo`/`Id` only used as last resort — those are human-readable labels
- * (e.g. "PER-2026-I") and passing them to /estudiantes as Periodo yields
- * zero rows on most Q10 plans.
- */
 function periodKey(p: Item): string {
-  return String(
-    p.Consecutivo ?? p.Consecutivo_periodo ?? p.Codigo ?? p.Id ?? '',
+  return (
+    cleanStr(p.Consecutivo) ||
+    cleanStr(p.Consecutivo_periodo) ||
+    cleanStr(p.Codigo) ||
+    cleanStr(p.Id)
   );
 }
 
-/**
- * Best-effort "effective creation date" for a student — tries Fecha_creacion
- * first, falls back to Fecha_matricula. Centralised so filter + chart bucketing
- * use the same derived field; otherwise a student matched via Fecha_matricula
- * would pass the range filter but contribute 0 to the bucket grouped by
- * Fecha_creacion, making `kpis.newStudentsInRange` smaller than the chart.
- */
-function effectiveStudentDate(s: Item): string | null {
-  const v = s.Fecha_creacion ?? s.Fecha_matricula ?? null;
-  return typeof v === 'string' ? v : null;
+/** Assemble a student full name from Q10's split fields. */
+function studentFullName(s: Item): string {
+  // /pagosPendientes nests Estudiante with a pre-joined `Nombre_completo`.
+  const joined = cleanStr(s.Nombre_completo);
+  if (joined) return joined;
+  return [s.Primer_nombre, s.Segundo_nombre, s.Primer_apellido, s.Segundo_apellido]
+    .map(cleanStr)
+    .filter(Boolean)
+    .join(' ');
 }
 
 function isoDate(d: Date): string {
@@ -93,8 +98,7 @@ export class DashboardService {
   ): Promise<T[]> {
     try {
       // Uses getAll so the dashboard sees the whole dataset, not just the
-      // ~50 records Q10 returns on a single unpaginated call. safeArray
-      // normalises any unexpected wrapper shape to [].
+      // ~50 records Q10 returns on a single unpaginated call.
       return safeArray(await this.q10.getAll(path, params)) as T[];
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
@@ -105,34 +109,40 @@ export class DashboardService {
   }
 
   /**
-   * Endpoint usage follows Q10-JACK-API.md and the Q10 support confirmation
-   * (ticket with Diógenes): this institution runs the "pagos regulares"
-   * financial model, so:
+   * Shape and field names are aligned with a live /diagnose run against
+   * Genius Idiomas' Q10 tenant (Costa Rica, ETDH, "pagos regulares" model).
    *
-   *   FINANCIAL sources USED:
-   *     - /pagos?Fecha_inicio&Fecha_fin       (actual payments in range)
-   *     - /pagosPendientes?Consecutivo_periodo (outstanding per period — P caps!)
-   *     - /estadocuentaestudiantes             (consolidated per-student balance)
+   * What this plan exposes:
+   *   - /estudiantes?Periodo={Consecutivo}           — Primer_nombre,
+   *     Primer_apellido, Nombre_programa, Nombre_sede, Condicion_matricula,
+   *     Fecha_matricula, Codigo_estudiante (12 digits).
+   *   - /pagos?Fecha_inicio&Fecha_fin                — Codigo_persona (maps
+   *     to Codigo_estudiante), Valor_pagado, Fecha_pago, Nombre_estudiante.
+   *   - /pagosPendientes?Consecutivo_periodo         — Valor_saldo,
+   *     Nombre_producto, Nombre_periodo, Estudiante (nested object with
+   *     Codigo_persona + Nombre_completo).
+   *   - /oportunidades?Fecha_inicio&Fecha_fin        — Consecutivo_oportunidad,
+   *     Nombre_oportunidad, Descripcion_como_se_entero (origin),
+   *     Descripcion_medio_contacto.
+   *   - /contactos, /periodos, /programas, /sedes,
+   *     /mediospublicitarios?Estado=true, /medioscontacto?Estado=true.
    *
-   *   FINANCIAL sources NOT applicable to this plan (Q10 reply):
-   *     - /ordenespago, /facturas             (other financial models only)
-   *
-   *   STUDENT list requires ?Periodo={Consecutivo} — we fan out over active
-   *   periods and dedupe.
-   *
-   *   CRM sources (/oportunidades, /negocios) require Fecha_inicio+Fecha_fin;
-   *   we use a wide window for KPIs that need the full historical dataset.
-   *
-   *   /matriculasProgramas is POST-only per the doc; "enrollments" in the
-   *   funnel derives from the active-period student count (equivalent for
-   *   this school — a student in an active period = a matrícula).
+   * What this plan DOES NOT expose (verified 2026-04-21):
+   *   - /ordenespago, /facturas                      — "no aplica al modelo"
+   *   - /estadocuentaestudiantes                     — "no aplica al modelo
+   *     financiero correspondiente" (Q10 support initially suggested it,
+   *     but the tenant's model forbids it — see diagnostic).
+   *   - /negocios                                    — returns 400 on every
+   *     param combination tried (noparam, Fecha_inicio/fin, Estado,
+   *     Consecutivo_flujo). Not called from here until Q10 clarifies.
+   *   - /matriculasProgramas                         — POST-only per the
+   *     doc. Funnel `enrollments` = active-period student count.
    */
   async overview(rangeDays = 30) {
     const errors: Record<string, string> = {};
     const degraded: Record<string, string> = {};
     const ALL_TIME = { Fecha_inicio: '1900-01-01', Fecha_fin: '2099-12-31' };
 
-    // Range window for /pagos — server-side filtered so we don't drag lifetime.
     const rangeEnd = new Date();
     const rangeStart = new Date(Date.now() - rangeDays * 24 * 60 * 60 * 1000);
     const RANGE = {
@@ -140,17 +150,17 @@ export class DashboardService {
       Fecha_fin: isoDate(rangeEnd),
     };
 
-    // Non-dependent sources in parallel
-    const [periodos, contactos, opps, deals, estadoCuenta, pagos] = await Promise.all([
+    // Non-dependent sources in parallel. /negocios and /estadocuentaestudiantes
+    // are NOT here — this plan rejects both with 400. Re-add if Q10 enables them.
+    const [periodos, contactos, opps, pagos] = await Promise.all([
       this.tryFetch<Item>('periods', '/periodos', errors),
       this.tryFetch<Item>('contacts', '/contactos', errors),
       this.tryFetch<Item>('opportunities', '/oportunidades', errors, ALL_TIME),
-      this.tryFetch<Item>('deals', '/negocios', errors, ALL_TIME),
-      this.tryFetch<Item>('estadoCuenta', '/estadocuentaestudiantes', errors),
       this.tryFetch<Item>('payments', '/pagos', errors, RANGE),
     ]);
 
-    // Students + pending payments — one call per active period
+    // Students + pending payments — one call per active period (doc requires
+    // Periodo / Consecutivo_periodo).
     const active = currentlyActivePeriods(periodos);
     let students: Item[] = [];
     let pending: Item[] = [];
@@ -184,7 +194,7 @@ export class DashboardService {
       const seenStudents = new Set<string>();
       for (const list of studentLists) {
         for (const s of list) {
-          const id = String(s.Codigo_estudiante ?? s.Codigo ?? s.Id ?? '');
+          const id = cleanStr(s.Codigo_estudiante);
           if (!id || seenStudents.has(id)) continue;
           seenStudents.add(id);
           students.push(s);
@@ -194,76 +204,82 @@ export class DashboardService {
     }
 
     // ─── Students ───
-    const activeStudents = students.filter(
-      (s) =>
-        isActivo(s.Estado) ||
-        String(s.Estado ?? '').toLowerCase().includes('matricul'),
-    );
+    // Q10 /estudiantes?Periodo=X already filters to the active cohort; every
+    // returned record is matriculated. Condicion_matricula tells whether it's
+    // a fresh enrollment ("Nuevo") vs a renewal ("Renovado").
+    const newEnrollmentsThisPeriod = students.filter(
+      (s) => cleanStr(s.Condicion_matricula).toLowerCase() === 'nuevo',
+    ).length;
+
+    const newStudentsInRange = students.filter((s) => {
+      const d = parseDate(s.Fecha_matricula);
+      return d !== null && d.getTime() >= rangeStart.getTime();
+    });
 
     // ─── CRM ───
-    const oppsWon = opps.filter((o) => {
-      const e = String(o.Estado ?? '').toLowerCase();
-      return e.includes('inscri') || e.includes('ganad');
-    }).length;
-    const oppsLost = opps.filter((o) =>
-      String(o.Estado ?? '').toLowerCase().includes('perdi'),
-    ).length;
-    const oppsOpen = Math.max(0, opps.length - oppsWon - oppsLost);
-    const conversionRate =
-      opps.length > 0 ? Math.round((oppsWon / opps.length) * 100) : 0;
+    // This plan's /oportunidades records don't expose a top-level Estado —
+    // the state lives inside Negocio_favorito (nested object). Until we can
+    // reliably parse that, we report total opps and mark the conversion-rate
+    // KPI as degraded so the UI can hide it.
+    const oppsTotal = opps.length;
+    const conversionRateDegraded =
+      oppsTotal === 0 || oppsTotal < Math.max(5, students.length * 0.1);
+    if (conversionRateDegraded) {
+      degraded.conversionRate =
+        oppsTotal === 0
+          ? 'Sin oportunidades en el CRM'
+          : `Sólo ${oppsTotal} oportunidades para ${students.length} matrículas — CRM subutilizado, la tasa no es confiable`;
+    }
 
     // ─── Financial ───
-    // /pagos is already server-side filtered by RANGE (Fecha_inicio/Fecha_fin).
-    const revenueInRange = sum(pagos, 'Valor');
-    const outstandingDebt = sum(pending, 'Valor');
-    const overduePending = pending.filter((p) => {
-      const due = parseDate(p.Fecha_vencimiento);
-      return due !== null && due.getTime() < Date.now();
-    });
-    // Consolidated balances from /estadocuentaestudiantes — useful for
-    // reconciliation. `studentsWithDebt` is an institution-wide figure
-    // (historical + current), so keep it unscoped to mirror the accountant
-    // view. `paidEnrollments` is a funnel metric, so it MUST be scoped to
-    // students in the currently-active periods — otherwise historical paid
-    // students would inflate the funnel above the current-period cohort.
-    const studentsWithDebt = estadoCuenta.filter((e) => Number(e.Saldo) > 0);
+    const revenueInRange = sum(pagos, 'Valor_pagado');
+    const outstandingDebt = sum(pending, 'Valor_saldo');
+    // /pagosPendientes on this plan has no Fecha_vencimiento — overdue count
+    // isn't available. Expose that clearly instead of lying with 0.
+    degraded.overduePending =
+      '/pagosPendientes no expone Fecha_vencimiento en este plan';
 
+    // Students who have at least one payment in the range (intersection
+    // between /pagos Codigo_persona and /estudiantes Codigo_estudiante —
+    // both are the same 12-digit internal person code).
     const currentStudentIds = new Set(
-      students.map((s) => String(s.Codigo_estudiante ?? s.Codigo ?? s.Id ?? '')),
+      students.map((s) => cleanStr(s.Codigo_estudiante)).filter(Boolean),
     );
-    const paidCurrentStudents = estadoCuenta.filter((e) => {
-      if (Number(e.Saldo) !== 0 || Number(e.Total_pagado) <= 0) return false;
-      const id = String(e.Codigo_estudiante ?? e.Codigo ?? e.Id ?? '');
-      return currentStudentIds.has(id);
-    });
+    const paidCodigos = new Set(
+      pagos.map((p) => cleanStr(p.Codigo_persona)).filter(Boolean),
+    );
+    const paidCurrentCount = [...paidCodigos].filter((id) =>
+      currentStudentIds.has(id),
+    ).length;
 
-    // ─── Funnel (see class doc for why enrollments = students.length) ───
+    // ─── Funnel ───
     const funnel = {
-      opportunities: opps.length,
+      opportunities: oppsTotal,
       enrollments: students.length,
-      paidEnrollments: paidCurrentStudents.length,
+      paidEnrollments: paidCurrentCount,
     };
 
-    // Normalise the effective creation date once so the filter and the
-    // bucketByDay call agree on which field to look at (prevents off-by-one
-    // between `kpis.newStudentsInRange` and the chart).
-    const studentsWithEffectiveDate = students
-      .map((s) => ({ ...s, _EffectiveDate: effectiveStudentDate(s) }))
-      .filter((s): s is Item & { _EffectiveDate: string } => {
-        const d = parseDate(s._EffectiveDate);
-        return d !== null && d.getTime() >= rangeStart.getTime();
-      });
     const newStudentsByDay = this.bucketByDay(
-      studentsWithEffectiveDate,
-      '_EffectiveDate',
+      newStudentsInRange,
+      'Fecha_matricula',
       null,
       rangeDays,
     );
-    const revenueByDay = this.bucketByDay(pagos, 'Fecha_pago', 'Valor', rangeDays);
+    const revenueByDay = this.bucketByDay(
+      pagos,
+      'Fecha_pago',
+      'Valor_pagado',
+      rangeDays,
+    );
 
-    const studentsByProgram = groupCount(students, 'Codigo_programa');
-    const studentsBySede = groupCount(students, 'Codigo_sede');
-    const opportunitiesByOrigin = groupCount(opps, 'Origen');
+    // Display-friendly groupings. Use the `Nombre_*` fields so the UI
+    // shows "Curso de Português" instead of the "01" code.
+    const studentsByProgram = groupCount(students, (s) => s.Nombre_programa);
+    const studentsBySede = groupCount(students, (s) => s.Nombre_sede);
+    const opportunitiesByOrigin = groupCount(
+      opps,
+      (o) => o.Descripcion_como_se_entero,
+    );
 
     return {
       range: { days: rangeDays, generatedAt: new Date().toISOString() },
@@ -271,20 +287,17 @@ export class DashboardService {
       errors,
       degraded,
       kpis: {
-        activeStudents: activeStudents.length,
+        activeStudents: students.length,
         totalStudents: students.length,
-        newStudentsInRange: newStudentsByDay.reduce((s, p) => s + p.value, 0),
+        newEnrollmentsThisPeriod,
+        newStudentsInRange: newStudentsInRange.length,
         totalContacts: contactos.length,
-        oppsOpen,
-        oppsWon,
-        oppsLost,
-        conversionRate,
+        oppsTotal,
+        conversionRate: conversionRateDegraded ? null : 0,
         revenueInRange,
         outstandingDebt,
-        overduePending: overduePending.length,
         ordersPending: pending.length,
-        activeDeals: deals.length,
-        studentsWithDebt: studentsWithDebt.length,
+        paidStudents: paidCurrentCount,
       },
       funnel,
       charts: { revenueByDay, newStudentsByDay },
@@ -293,17 +306,36 @@ export class DashboardService {
         studentsBySede,
         opportunitiesByOrigin,
       },
+      // Normalised shapes — frontend stays simple because we do the
+      // field mapping here once instead of scattering it through the UI.
       recent: {
-        students: students.slice(-10).reverse(),
-        opportunities: opps.slice(-10).reverse(),
-        pendingPayments: pending
-          .slice()
-          .sort((a, b) => {
-            const da = parseDate(a.Fecha_vencimiento)?.getTime() ?? Infinity;
-            const db = parseDate(b.Fecha_vencimiento)?.getTime() ?? Infinity;
-            return da - db;
-          })
-          .slice(0, 10),
+        students: students.slice(-10).reverse().map((s) => ({
+          Codigo: cleanStr(s.Codigo_estudiante),
+          Nombres: [s.Primer_nombre, s.Segundo_nombre].map(cleanStr).filter(Boolean).join(' '),
+          Apellidos: [s.Primer_apellido, s.Segundo_apellido].map(cleanStr).filter(Boolean).join(' '),
+          Codigo_programa: cleanStr(s.Nombre_programa) || cleanStr(s.Codigo_programa),
+          Codigo_sede: cleanStr(s.Nombre_sede) || cleanStr(s.Codigo_sede),
+          Estado: cleanStr(s.Condicion_matricula) || 'Matriculado',
+        })),
+        opportunities: opps.slice(-10).reverse().map((o) => ({
+          Codigo: cleanStr(o.Consecutivo_oportunidad),
+          Nombres: cleanStr(o.Nombre_oportunidad),
+          Apellidos: '',
+          Correo: cleanStr(o.Correo_electronico),
+          Telefono: cleanStr(o.Celular ?? o.Telefono),
+          Origen: cleanStr(o.Descripcion_como_se_entero),
+          Estado: cleanStr(o.Nombre_asesor) ? 'Con asesor' : 'Sin asignar',
+        })),
+        pendingPayments: pending.slice(0, 10).map((p) => {
+          const e = p.Estudiante && typeof p.Estudiante === 'object' ? p.Estudiante : {};
+          return {
+            Nombres: studentFullName(e) || '—',
+            Apellidos: '',
+            Concepto: cleanStr(p.Nombre_producto),
+            Valor: Number(p.Valor_saldo) || 0,
+            Fecha_vencimiento: `Período ${cleanStr(p.Nombre_periodo) || '—'}`,
+          };
+        }),
       },
     };
   }

--- a/src/q10/dashboard.service.ts
+++ b/src/q10/dashboard.service.ts
@@ -1,88 +1,16 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { Q10ClientService } from './q10-client.service';
-
-type Item = Record<string, any>;
-
-function safeArray(v: unknown): Item[] {
-  if (Array.isArray(v)) return v as Item[];
-  if (v && typeof v === 'object') {
-    const maybeList = (v as any).items ?? (v as any).data ?? (v as any).results;
-    if (Array.isArray(maybeList)) return maybeList;
-  }
-  return [];
-}
-
-function parseDate(value: unknown): Date | null {
-  if (!value || typeof value !== 'string') return null;
-  const d = new Date(value);
-  return isNaN(d.getTime()) ? null : d;
-}
-
-/** Trim + treat literal "null" strings as empty (Q10 serialises nulls that way). */
-function cleanStr(v: unknown): string {
-  if (v == null) return '';
-  const s = String(v).trim();
-  return s === 'null' ? '' : s;
-}
-
-/** Q10 serialises booleans as the literal string "true"/"false" sometimes. */
-function isActivo(status: unknown): boolean {
-  if (status === true) return true;
-  const s = cleanStr(status).toLowerCase();
-  return s === 'true' || s.includes('activ');
-}
-
-function sum(list: Item[], field: string): number {
-  return list.reduce((acc, x) => acc + (Number(x[field]) || 0), 0);
-}
-
-function groupCount<T extends Item>(
-  list: T[],
-  getter: (item: T) => unknown,
-): Record<string, number> {
-  const out: Record<string, number> = {};
-  for (const item of list) {
-    const key = cleanStr(getter(item)) || 'Sin especificar';
-    out[key] = (out[key] ?? 0) + 1;
-  }
-  return out;
-}
-
-/** Pick periods considered active right now. */
-function currentlyActivePeriods(periodos: Item[]): Item[] {
-  const now = Date.now();
-  const active = periodos.filter((p) => isActivo(p.Estado));
-  const current = active.filter((p) => {
-    const start = parseDate(p.Fecha_inicio)?.getTime() ?? -Infinity;
-    const end = parseDate(p.Fecha_fin)?.getTime() ?? Infinity;
-    return now >= start && now <= end;
-  });
-  return current.length > 0 ? current : active;
-}
-
-function periodKey(p: Item): string {
-  return (
-    cleanStr(p.Consecutivo) ||
-    cleanStr(p.Consecutivo_periodo) ||
-    cleanStr(p.Codigo) ||
-    cleanStr(p.Id)
-  );
-}
-
-/** Assemble a student full name from Q10's split fields. */
-function studentFullName(s: Item): string {
-  // /pagosPendientes nests Estudiante with a pre-joined `Nombre_completo`.
-  const joined = cleanStr(s.Nombre_completo);
-  if (joined) return joined;
-  return [s.Primer_nombre, s.Segundo_nombre, s.Primer_apellido, s.Segundo_apellido]
-    .map(cleanStr)
-    .filter(Boolean)
-    .join(' ');
-}
-
-function isoDate(d: Date): string {
-  return d.toISOString().slice(0, 10);
-}
+import {
+  cleanStr,
+  currentlyActivePeriods,
+  isoDate,
+  Item,
+  parseDate,
+  periodKey,
+  safeArray,
+  studentFullName,
+  sum,
+} from './dashboard/helpers';
 
 @Injectable()
 export class DashboardService {
@@ -97,8 +25,6 @@ export class DashboardService {
     params?: Record<string, unknown>,
   ): Promise<T[]> {
     try {
-      // Uses getAll so the dashboard sees the whole dataset, not just the
-      // ~50 records Q10 returns on a single unpaginated call.
       return safeArray(await this.q10.getAll(path, params)) as T[];
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
@@ -109,34 +35,10 @@ export class DashboardService {
   }
 
   /**
-   * Shape and field names are aligned with a live /diagnose run against
-   * Genius Idiomas' Q10 tenant (Costa Rica, ETDH, "pagos regulares" model).
-   *
-   * What this plan exposes:
-   *   - /estudiantes?Periodo={Consecutivo}           — Primer_nombre,
-   *     Primer_apellido, Nombre_programa, Nombre_sede, Condicion_matricula,
-   *     Fecha_matricula, Codigo_estudiante (12 digits).
-   *   - /pagos?Fecha_inicio&Fecha_fin                — Codigo_persona (maps
-   *     to Codigo_estudiante), Valor_pagado, Fecha_pago, Nombre_estudiante.
-   *   - /pagosPendientes?Consecutivo_periodo         — Valor_saldo,
-   *     Nombre_producto, Nombre_periodo, Estudiante (nested object with
-   *     Codigo_persona + Nombre_completo).
-   *   - /oportunidades?Fecha_inicio&Fecha_fin        — Consecutivo_oportunidad,
-   *     Nombre_oportunidad, Descripcion_como_se_entero (origin),
-   *     Descripcion_medio_contacto.
-   *   - /contactos, /periodos, /programas, /sedes,
-   *     /mediospublicitarios?Estado=true, /medioscontacto?Estado=true.
-   *
-   * What this plan DOES NOT expose (verified 2026-04-21):
-   *   - /ordenespago, /facturas                      — "no aplica al modelo"
-   *   - /estadocuentaestudiantes                     — "no aplica al modelo
-   *     financiero correspondiente" (Q10 support initially suggested it,
-   *     but the tenant's model forbids it — see diagnostic).
-   *   - /negocios                                    — returns 400 on every
-   *     param combination tried (noparam, Fecha_inicio/fin, Estado,
-   *     Consecutivo_flujo). Not called from here until Q10 clarifies.
-   *   - /matriculasProgramas                         — POST-only per the
-   *     doc. Funnel `enrollments` = active-period student count.
+   * Visión general — the main tab. Keeps the original field mapping aligned
+   * with the live Q10 tenant (Costa Rica, ETDH, "pagos regulares" model).
+   * Deeper drill-downs live on the sibling services: AcademicService,
+   * FinancialService, CommercialService.
    */
   async overview(rangeDays = 30) {
     const errors: Record<string, string> = {};
@@ -150,8 +52,6 @@ export class DashboardService {
       Fecha_fin: isoDate(rangeEnd),
     };
 
-    // Non-dependent sources in parallel. /negocios and /estadocuentaestudiantes
-    // are NOT here — this plan rejects both with 400. Re-add if Q10 enables them.
     const [periodos, contactos, opps, pagos] = await Promise.all([
       this.tryFetch<Item>('periods', '/periodos', errors),
       this.tryFetch<Item>('contacts', '/contactos', errors),
@@ -159,8 +59,6 @@ export class DashboardService {
       this.tryFetch<Item>('payments', '/pagos', errors, RANGE),
     ]);
 
-    // Students + pending payments — one call per active period (doc requires
-    // Periodo / Consecutivo_periodo).
     const active = currentlyActivePeriods(periodos);
     let students: Item[] = [];
     let pending: Item[] = [];
@@ -203,10 +101,6 @@ export class DashboardService {
       pending = pendingLists.flat();
     }
 
-    // ─── Students ───
-    // Q10 /estudiantes?Periodo=X already filters to the active cohort; every
-    // returned record is matriculated. Condicion_matricula tells whether it's
-    // a fresh enrollment ("Nuevo") vs a renewal ("Renovado").
     const newEnrollmentsThisPeriod = students.filter(
       (s) => cleanStr(s.Condicion_matricula).toLowerCase() === 'nuevo',
     ).length;
@@ -216,32 +110,31 @@ export class DashboardService {
       return d !== null && d.getTime() >= rangeStart.getTime();
     });
 
-    // ─── CRM ───
-    // This plan's /oportunidades records don't expose a top-level Estado —
-    // the state lives inside Negocio_favorito (nested object). Until we can
-    // reliably parse that, we report total opps and mark the conversion-rate
-    // KPI as degraded so the UI can hide it.
+    // Conversion rate, real this time — /oportunidades carries Negocio_favorito
+    // with Estado_negocio (see raw Q10 dump: "Presentación"/"Ganada"/etc).
     const oppsTotal = opps.length;
+    const oppsWon = opps.filter((o) => {
+      const e = cleanStr(o.Negocio_favorito?.Estado_negocio).toLowerCase();
+      return e.includes('ganad');
+    }).length;
     const conversionRateDegraded =
       oppsTotal === 0 || oppsTotal < Math.max(5, students.length * 0.1);
     if (conversionRateDegraded) {
       degraded.conversionRate =
         oppsTotal === 0
           ? 'Sin oportunidades en el CRM'
-          : `Sólo ${oppsTotal} oportunidades para ${students.length} matrículas — CRM subutilizado, la tasa no es confiable`;
+          : `Sólo ${oppsTotal} oportunidades para ${students.length} matrículas — CRM subutilizado`;
     }
+    const conversionRate =
+      !conversionRateDegraded && oppsTotal > 0
+        ? Math.round((oppsWon / oppsTotal) * 100)
+        : null;
 
-    // ─── Financial ───
     const revenueInRange = sum(pagos, 'Valor_pagado');
     const outstandingDebt = sum(pending, 'Valor_saldo');
-    // /pagosPendientes on this plan has no Fecha_vencimiento — overdue count
-    // isn't available. Expose that clearly instead of lying with 0.
     degraded.overduePending =
       '/pagosPendientes no expone Fecha_vencimiento en este plan';
 
-    // Students who have at least one payment in the range (intersection
-    // between /pagos Codigo_persona and /estudiantes Codigo_estudiante —
-    // both are the same 12-digit internal person code).
     const currentStudentIds = new Set(
       students.map((s) => cleanStr(s.Codigo_estudiante)).filter(Boolean),
     );
@@ -252,7 +145,6 @@ export class DashboardService {
       currentStudentIds.has(id),
     ).length;
 
-    // ─── Funnel ───
     const funnel = {
       opportunities: oppsTotal,
       enrollments: students.length,
@@ -272,15 +164,6 @@ export class DashboardService {
       rangeDays,
     );
 
-    // Display-friendly groupings. Use the `Nombre_*` fields so the UI
-    // shows "Curso de Português" instead of the "01" code.
-    const studentsByProgram = groupCount(students, (s) => s.Nombre_programa);
-    const studentsBySede = groupCount(students, (s) => s.Nombre_sede);
-    const opportunitiesByOrigin = groupCount(
-      opps,
-      (o) => o.Descripcion_como_se_entero,
-    );
-
     return {
       range: { days: rangeDays, generatedAt: new Date().toISOString() },
       partial: Object.keys(errors).length > 0,
@@ -293,7 +176,8 @@ export class DashboardService {
         newStudentsInRange: newStudentsInRange.length,
         totalContacts: contactos.length,
         oppsTotal,
-        conversionRate: conversionRateDegraded ? null : 0,
+        oppsWon,
+        conversionRate,
         revenueInRange,
         outstandingDebt,
         ordersPending: pending.length,
@@ -301,33 +185,28 @@ export class DashboardService {
       },
       funnel,
       charts: { revenueByDay, newStudentsByDay },
-      distributions: {
-        studentsByProgram,
-        studentsBySede,
-        opportunitiesByOrigin,
-      },
-      // Normalised shapes — frontend stays simple because we do the
-      // field mapping here once instead of scattering it through the UI.
       recent: {
-        students: students.slice(-10).reverse().map((s) => ({
-          Codigo: cleanStr(s.Codigo_estudiante),
-          Nombres: [s.Primer_nombre, s.Segundo_nombre].map(cleanStr).filter(Boolean).join(' '),
-          Apellidos: [s.Primer_apellido, s.Segundo_apellido].map(cleanStr).filter(Boolean).join(' '),
-          Codigo_programa: cleanStr(s.Nombre_programa) || cleanStr(s.Codigo_programa),
-          Codigo_sede: cleanStr(s.Nombre_sede) || cleanStr(s.Codigo_sede),
-          Estado: cleanStr(s.Condicion_matricula) || 'Matriculado',
-        })),
-        opportunities: opps.slice(-10).reverse().map((o) => ({
-          Codigo: cleanStr(o.Consecutivo_oportunidad),
-          Nombres: cleanStr(o.Nombre_oportunidad),
-          Apellidos: '',
-          Correo: cleanStr(o.Correo_electronico),
-          Telefono: cleanStr(o.Celular ?? o.Telefono),
-          Origen: cleanStr(o.Descripcion_como_se_entero),
-          Estado: cleanStr(o.Nombre_asesor) ? 'Con asesor' : 'Sin asignar',
-        })),
+        students: students
+          .slice(-10)
+          .reverse()
+          .map((s) => ({
+            Codigo: cleanStr(s.Codigo_estudiante),
+            Nombres: [s.Primer_nombre, s.Segundo_nombre]
+              .map(cleanStr)
+              .filter(Boolean)
+              .join(' '),
+            Apellidos: [s.Primer_apellido, s.Segundo_apellido]
+              .map(cleanStr)
+              .filter(Boolean)
+              .join(' '),
+            Codigo_programa:
+              cleanStr(s.Nombre_programa) || cleanStr(s.Codigo_programa),
+            Codigo_sede: cleanStr(s.Nombre_sede) || cleanStr(s.Codigo_sede),
+            Estado: cleanStr(s.Condicion_matricula) || 'Matriculado',
+          })),
         pendingPayments: pending.slice(0, 10).map((p) => {
-          const e = p.Estudiante && typeof p.Estudiante === 'object' ? p.Estudiante : {};
+          const e =
+            p.Estudiante && typeof p.Estudiante === 'object' ? p.Estudiante : {};
           return {
             Nombres: studentFullName(e) || '—',
             Apellidos: '',

--- a/src/q10/dashboard.service.ts
+++ b/src/q10/dashboard.service.ts
@@ -125,10 +125,12 @@ export class DashboardService {
           ? 'Sin oportunidades en el CRM'
           : `Sólo ${oppsTotal} oportunidades para ${students.length} matrículas — CRM subutilizado`;
     }
-    const conversionRate =
-      !conversionRateDegraded && oppsTotal > 0
-        ? Math.round((oppsWon / oppsTotal) * 100)
-        : null;
+    // When oppsTotal is meaningful (not degraded), compute the actual rate.
+    // Previously this branch returned literal `0` when degraded, but the UI
+    // already hides the card in that case — keeping it `null` is unambiguous.
+    const conversionRate = conversionRateDegraded
+      ? null
+      : Math.round((oppsWon / oppsTotal) * 100);
 
     const revenueInRange = sum(pagos, 'Valor_pagado');
     const outstandingDebt = sum(pending, 'Valor_saldo');
@@ -181,7 +183,10 @@ export class DashboardService {
         revenueInRange,
         outstandingDebt,
         ordersPending: pending.length,
-        paidStudents: paidCurrentCount,
+        // Renamed from `paidStudents` for clarity (review #7): this counts
+        // active-period students with at least one payment in the range,
+        // not "students with their tuition fully paid".
+        studentsWithPaymentThisPeriod: paidCurrentCount,
       },
       funnel,
       charts: { revenueByDay, newStudentsByDay },

--- a/src/q10/dashboard/academic.service.ts
+++ b/src/q10/dashboard/academic.service.ts
@@ -1,0 +1,171 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Q10ClientService } from '../q10-client.service';
+import {
+  ageBucket,
+  ageFromBirthdate,
+  cleanStr,
+  currentlyActivePeriods,
+  groupCount,
+  Item,
+  periodKey,
+  previousPeriod,
+  safeArray,
+} from './helpers';
+
+@Injectable()
+export class AcademicService {
+  private readonly logger = new Logger(AcademicService.name);
+
+  constructor(private readonly q10: Q10ClientService) {}
+
+  private async tryFetch<T>(
+    key: string,
+    path: string,
+    errors: Record<string, string>,
+    params?: Record<string, unknown>,
+  ): Promise<T[]> {
+    try {
+      return safeArray(await this.q10.getAll(path, params)) as T[];
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      errors[key] = message;
+      this.logger.warn(`[academic] ${path} failed: ${message}`);
+      return [];
+    }
+  }
+
+  /**
+   * Composition of the school + retention across periods. Everything here
+   * comes straight out of /estudiantes (34 fields per record) so we don't
+   * hit endpoints that are unavailable on this Q10 plan.
+   *
+   * Retention compares the student list of the currently-active period with
+   * the one immediately before it (most recent Fecha_fin) — the classic
+   * cohort shape: retained / churned / newcomers. `Condicion_matricula` is
+   * NOT used for this because the live dump confirmed it's null for all P1
+   * records on this tenant — the field was populated starting from P2.
+   */
+  async academic() {
+    const errors: Record<string, string> = {};
+    const degraded: Record<string, string> = {};
+
+    const [periodos, docentes] = await Promise.all([
+      this.tryFetch<Item>('periods', '/periodos', errors),
+      this.tryFetch<Item>('teachers', '/docentes', errors),
+    ]);
+
+    const active = currentlyActivePeriods(periodos);
+    const previous = previousPeriod(periodos, active);
+
+    let currentStudents: Item[] = [];
+    let previousStudents: Item[] = [];
+
+    if (active.length > 0) {
+      const lists = await Promise.all(
+        active.map((p) =>
+          this.tryFetch<Item>('students', '/estudiantes', errors, {
+            Periodo: periodKey(p),
+          }),
+        ),
+      );
+      const seen = new Set<string>();
+      for (const list of lists) {
+        for (const s of list) {
+          const id = cleanStr(s.Codigo_estudiante);
+          if (!id || seen.has(id)) continue;
+          seen.add(id);
+          currentStudents.push(s);
+        }
+      }
+    } else {
+      degraded.currentStudents = 'Sin períodos activos';
+    }
+
+    if (previous) {
+      previousStudents = await this.tryFetch<Item>(
+        'previousStudents',
+        '/estudiantes',
+        errors,
+        { Periodo: periodKey(previous) },
+      );
+    } else {
+      degraded.retention = 'Sin período anterior para comparar';
+    }
+
+    // ─── Retention / churn — set-based comparison ───
+    const prevIds = new Set(previousStudents.map((s) => cleanStr(s.Codigo_estudiante)).filter(Boolean));
+    const curIds = new Set(currentStudents.map((s) => cleanStr(s.Codigo_estudiante)).filter(Boolean));
+    const retained = [...prevIds].filter((id) => curIds.has(id));
+    const churned = [...prevIds].filter((id) => !curIds.has(id));
+    const newcomers = [...curIds].filter((id) => !prevIds.has(id));
+
+    const retention = {
+      previousPeriod: previous ? cleanStr(previous.Nombre) : null,
+      currentPeriod: active[0] ? cleanStr(active[0].Nombre) : null,
+      previousTotal: prevIds.size,
+      currentTotal: curIds.size,
+      retained: retained.length,
+      churned: churned.length,
+      newcomers: newcomers.length,
+      retentionRate: prevIds.size > 0 ? Math.round((retained.length / prevIds.size) * 100) : null,
+      churnRate: prevIds.size > 0 ? Math.round((churned.length / prevIds.size) * 100) : null,
+    };
+
+    // ─── Distributions ───
+    const byJornada = groupCount(currentStudents, (s) => s.Nombre_jornada);
+    const byNivel = groupCount(currentStudents, (s) => s.Nombre_nivel);
+    const bySedeJornada = groupCount(currentStudents, (s) => s.Nombre_sedejornada);
+    const byProgram = groupCount(currentStudents, (s) => s.Nombre_programa);
+    const byCondicion = groupCount(currentStudents, (s) =>
+      cleanStr(s.Condicion_matricula) || 'Sin dato',
+    );
+
+    // Gender + age
+    const gender = groupCount(currentStudents, (s) => {
+      const g = cleanStr(s.Genero).toUpperCase();
+      if (g === 'F') return 'Femenino';
+      if (g === 'M') return 'Masculino';
+      return 'No informado';
+    });
+    const ages = currentStudents
+      .map((s) => ageFromBirthdate(s.Fecha_nacimiento))
+      .filter((a): a is number => a !== null);
+    const ageDistribution: Record<string, number> = {};
+    for (const a of ages) {
+      const bucket = ageBucket(a);
+      ageDistribution[bucket] = (ageDistribution[bucket] ?? 0) + 1;
+    }
+    const avgAge = ages.length > 0 ? Math.round(ages.reduce((a, b) => a + b, 0) / ages.length) : null;
+
+    return {
+      generatedAt: new Date().toISOString(),
+      partial: Object.keys(errors).length > 0,
+      errors,
+      degraded,
+      summary: {
+        totalStudents: currentStudents.length,
+        totalTeachers: docentes.length,
+        avgAge,
+        currentPeriod: retention.currentPeriod,
+      },
+      retention,
+      distributions: {
+        byJornada,
+        byNivel,
+        bySedeJornada,
+        byProgram,
+        byCondicion,
+        byGender: gender,
+        byAge: ageDistribution,
+      },
+      teachers: docentes.slice(0, 20).map((d) => ({
+        Codigo: cleanStr(d.Codigo),
+        Nombres: [d.Primer_nombre, d.Segundo_nombre].map(cleanStr).filter(Boolean).join(' '),
+        Apellidos: [d.Primer_apellido, d.Segundo_apellido].map(cleanStr).filter(Boolean).join(' '),
+        Email: cleanStr(d.Email),
+        Celular: cleanStr(d.Celular),
+        Genero: cleanStr(d.Genero),
+      })),
+    };
+  }
+}

--- a/src/q10/dashboard/commercial.service.ts
+++ b/src/q10/dashboard/commercial.service.ts
@@ -1,0 +1,170 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Q10ClientService } from '../q10-client.service';
+import {
+  cleanStr,
+  groupCount,
+  Item,
+  monthKey,
+  parseDate,
+  safeArray,
+} from './helpers';
+
+@Injectable()
+export class CommercialService {
+  private readonly logger = new Logger(CommercialService.name);
+
+  constructor(private readonly q10: Q10ClientService) {}
+
+  private async tryFetch<T>(
+    key: string,
+    path: string,
+    errors: Record<string, string>,
+    params?: Record<string, unknown>,
+  ): Promise<T[]> {
+    try {
+      return safeArray(await this.q10.getAll(path, params)) as T[];
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      errors[key] = message;
+      this.logger.warn(`[commercial] ${path} failed: ${message}`);
+      return [];
+    }
+  }
+
+  /**
+   * CRM deep-dive. All state is derived from /oportunidades thanks to
+   * the nested `Negocio_favorito` object — we don't need to hit /negocios
+   * per-opportunity (that endpoint only works with Consecutivo_oportunidad
+   * and would be N+1).
+   *
+   * On a tenant that doesn't populate the CRM, every KPI here is `0` — the
+   * service doesn't try to hide that. The UI marks the whole tab as
+   * "CRM vacío" when `summary.totalOpportunities === 0`.
+   */
+  async commercial() {
+    const errors: Record<string, string> = {};
+    const degraded: Record<string, string> = {};
+
+    const ALL_TIME = { Fecha_inicio: '1900-01-01', Fecha_fin: '2099-12-31' };
+
+    const [opps, contactos] = await Promise.all([
+      this.tryFetch<Item>('opportunities', '/oportunidades', errors, ALL_TIME),
+      this.tryFetch<Item>('contacts', '/contactos', errors),
+    ]);
+
+    // ─── Monthly leads trend (last 12 months) ───
+    const now = new Date();
+    const leadsByMonth: Record<string, number> = {};
+    for (let i = 11; i >= 0; i--) {
+      const d = new Date(now);
+      d.setMonth(d.getMonth() - i);
+      leadsByMonth[monthKey(d)] = 0;
+    }
+    for (const o of opps) {
+      const d = parseDate(o.Fecha_registro);
+      if (!d) continue;
+      const k = monthKey(d);
+      if (k in leadsByMonth) leadsByMonth[k] += 1;
+    }
+    const leadsSeries = Object.entries(leadsByMonth).map(([month, value]) => ({ month, value }));
+
+    // ─── Funnel states from Negocio_favorito.Estado_negocio ───
+    // Live dump: "Presentación" (in progress). Common Q10 values include
+    // "Ganada", "Perdida", "Negociación", "Contacto inicial", etc. We
+    // match case-insensitively by substring.
+    const stateBucket = (o: Item) => {
+      const raw = cleanStr(o.Negocio_favorito?.Estado_negocio).toLowerCase();
+      if (!raw) return 'Sin estado';
+      if (raw.includes('ganad')) return 'Ganada';
+      if (raw.includes('perdid')) return 'Perdida';
+      return 'En progreso';
+    };
+    const byState = groupCount(opps, stateBucket);
+    const won = byState['Ganada'] ?? 0;
+    const lost = byState['Perdida'] ?? 0;
+    const inProgress = byState['En progreso'] ?? 0;
+    const conversionRate = opps.length > 0
+      ? Math.round((won / opps.length) * 100)
+      : null;
+
+    // ─── Origens & canais ───
+    const byOrigin = groupCount(opps, (o) => o.Descripcion_como_se_entero);
+    const byContactChannel = groupCount(opps, (o) => o.Descripcion_medio_contacto);
+
+    const referralCount = opps.filter((o) => {
+      const origen = cleanStr(o.Descripcion_como_se_entero).toLowerCase();
+      return origen.includes('refer') || origen.includes('indic') || origen.includes('amig') || origen.includes('boca');
+    }).length;
+    const referralRate = opps.length > 0
+      ? Math.round((referralCount / opps.length) * 100)
+      : null;
+
+    // ─── Advisor workload ───
+    const advisorCount: Record<string, number> = {};
+    for (const o of opps) {
+      const advisor = cleanStr(o.Nombre_asesor) || 'Sin asignar';
+      advisorCount[advisor] = (advisorCount[advisor] ?? 0) + 1;
+    }
+    const advisors = Object.entries(advisorCount)
+      .map(([nombre, total]) => ({ nombre, total }))
+      .sort((a, b) => b.total - a.total);
+
+    // ─── Geografia (top municípios) ───
+    const byMunicipio = groupCount(opps, (o) => o.Nombre_municipio);
+    const topMunicipios = Object.entries(byMunicipio)
+      .map(([municipio, total]) => ({ municipio, total }))
+      .sort((a, b) => b.total - a.total)
+      .slice(0, 10);
+
+    // ─── Recent opportunities ───
+    const recentOpps = opps
+      .slice()
+      .sort((a, b) => {
+        const da = parseDate(a.Fecha_registro)?.getTime() ?? 0;
+        const db = parseDate(b.Fecha_registro)?.getTime() ?? 0;
+        return db - da;
+      })
+      .slice(0, 15)
+      .map((o) => ({
+        consecutivo: cleanStr(o.Consecutivo_oportunidad),
+        fecha: cleanStr(o.Fecha_registro).slice(0, 10),
+        nombre: cleanStr(o.Nombre_oportunidad),
+        correo: cleanStr(o.Correo_electronico),
+        celular: cleanStr(o.Celular),
+        origen: cleanStr(o.Descripcion_como_se_entero),
+        canal: cleanStr(o.Descripcion_medio_contacto),
+        estado: cleanStr(o.Negocio_favorito?.Estado_negocio) || 'Sin estado',
+        asesor: cleanStr(o.Nombre_asesor) || 'Sin asignar',
+        programa: cleanStr(o.Negocio_favorito?.Nombre_programa),
+      }));
+
+    return {
+      generatedAt: new Date().toISOString(),
+      partial: Object.keys(errors).length > 0,
+      errors,
+      degraded,
+      summary: {
+        totalOpportunities: opps.length,
+        totalContacts: contactos.length,
+        won,
+        lost,
+        inProgress,
+        conversionRate,
+        referralCount,
+        referralRate,
+        advisorCount: advisors.length,
+      },
+      charts: {
+        leadsByMonth: leadsSeries,
+        byState,
+        byOrigin,
+        byContactChannel,
+      },
+      tables: {
+        advisors,
+        topMunicipios,
+        recentOpps,
+      },
+    };
+  }
+}

--- a/src/q10/dashboard/financial.service.ts
+++ b/src/q10/dashboard/financial.service.ts
@@ -1,0 +1,220 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Q10ClientService } from '../q10-client.service';
+import {
+  cleanStr,
+  currentlyActivePeriods,
+  groupSum,
+  isoDate,
+  Item,
+  monthKey,
+  parseDate,
+  periodKey,
+  safeArray,
+  studentFullName,
+  sum,
+} from './helpers';
+
+@Injectable()
+export class FinancialService {
+  private readonly logger = new Logger(FinancialService.name);
+
+  constructor(private readonly q10: Q10ClientService) {}
+
+  private async tryFetch<T>(
+    key: string,
+    path: string,
+    errors: Record<string, string>,
+    params?: Record<string, unknown>,
+  ): Promise<T[]> {
+    try {
+      return safeArray(await this.q10.getAll(path, params)) as T[];
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      errors[key] = message;
+      this.logger.warn(`[financial] ${path} failed: ${message}`);
+      return [];
+    }
+  }
+
+  /**
+   * Financial deep-dive. All sums use the field names this Q10 plan
+   * actually returns (Valor_pagado / Valor_saldo, verified live), not the
+   * generic `Valor` that the doc hints at.
+   *
+   * /estadocuentaestudiantes is NOT called — this tenant rejects it with
+   * "no aplica al modelo financiero correspondiente". Reconciliation is
+   * done by intersecting /pagos.Codigo_persona with /estudiantes
+   * .Codigo_estudiante (both are the same 12-digit internal person code).
+   */
+  async financial(monthsBack = 12) {
+    const errors: Record<string, string> = {};
+    const degraded: Record<string, string> = {};
+
+    const now = new Date();
+    const rangeStart = new Date(now);
+    rangeStart.setMonth(rangeStart.getMonth() - monthsBack);
+
+    const [periodos, pagos] = await Promise.all([
+      this.tryFetch<Item>('periods', '/periodos', errors),
+      this.tryFetch<Item>('payments', '/pagos', errors, {
+        Fecha_inicio: isoDate(rangeStart),
+        Fecha_fin: isoDate(now),
+      }),
+    ]);
+
+    const active = currentlyActivePeriods(periodos);
+    let currentStudents: Item[] = [];
+    let pending: Item[] = [];
+
+    if (active.length > 0) {
+      const [sl, pl] = await Promise.all([
+        Promise.all(
+          active.map((p) =>
+            this.tryFetch<Item>('students', '/estudiantes', errors, {
+              Periodo: periodKey(p),
+            }),
+          ),
+        ),
+        Promise.all(
+          active.map((p) =>
+            this.tryFetch<Item>('pendingPayments', '/pagosPendientes', errors, {
+              Consecutivo_periodo: periodKey(p),
+            }),
+          ),
+        ),
+      ]);
+      const seen = new Set<string>();
+      for (const list of sl) {
+        for (const s of list) {
+          const id = cleanStr(s.Codigo_estudiante);
+          if (id && !seen.has(id)) { seen.add(id); currentStudents.push(s); }
+        }
+      }
+      pending = pl.flat();
+    } else {
+      degraded.pending = 'Sin períodos activos';
+    }
+
+    // ─── MRR monthly trend ───
+    const revenueByMonth: Record<string, number> = {};
+    for (let i = monthsBack - 1; i >= 0; i--) {
+      const d = new Date(now);
+      d.setMonth(d.getMonth() - i);
+      revenueByMonth[monthKey(d)] = 0;
+    }
+    for (const p of pagos) {
+      const d = parseDate(p.Fecha_pago);
+      if (!d) continue;
+      const k = monthKey(d);
+      if (k in revenueByMonth) {
+        revenueByMonth[k] += Number(p.Valor_pagado) || 0;
+      }
+    }
+    const revenueSeries = Object.entries(revenueByMonth).map(([month, value]) => ({
+      month,
+      value,
+    }));
+    const totalRevenue = sum(pagos, 'Valor_pagado');
+
+    // ─── Ticket + LTV approximation (revenue-per-paying-person) ───
+    const revenuePerPerson: Record<string, number> = {};
+    for (const p of pagos) {
+      const k = cleanStr(p.Codigo_persona);
+      if (!k) continue;
+      revenuePerPerson[k] = (revenuePerPerson[k] ?? 0) + (Number(p.Valor_pagado) || 0);
+    }
+    const payingTotals = Object.values(revenuePerPerson);
+    const avgTicket = payingTotals.length > 0
+      ? totalRevenue / payingTotals.length
+      : 0;
+    const ltvApprox = payingTotals.length > 0
+      ? payingTotals.reduce((a, b) => a + b, 0) / payingTotals.length
+      : 0;
+    const maxPaid = payingTotals.length > 0 ? Math.max(...payingTotals) : 0;
+
+    // ─── Debt + reconciliation ───
+    const outstandingDebt = sum(pending, 'Valor_saldo');
+    const currentStudentIds = new Set(
+      currentStudents.map((s) => cleanStr(s.Codigo_estudiante)).filter(Boolean),
+    );
+    const inadCodes = new Set<string>();
+    for (const p of pending) {
+      const c = cleanStr(p.Estudiante?.Codigo_persona);
+      if (c) inadCodes.add(c);
+    }
+    const activeWithDebt = [...inadCodes].filter((c) => currentStudentIds.has(c)).length;
+    const inadimplenciaRate = currentStudentIds.size > 0
+      ? Math.round((activeWithDebt / currentStudentIds.size) * 100)
+      : null;
+
+    // ─── Projection ───
+    const projectedThisPeriod = sum(pending, 'Valor_total');
+    const paidThisPeriod = sum(pending, 'Valor_pagado');
+    const projectionRate = projectedThisPeriod > 0
+      ? Math.round((paidThisPeriod / projectedThisPeriod) * 100)
+      : null;
+
+    // ─── Drill-downs ───
+    const topDebtors = pending
+      .slice()
+      .sort((a, b) => (Number(b.Valor_saldo) || 0) - (Number(a.Valor_saldo) || 0))
+      .slice(0, 15)
+      .map((p) => ({
+        estudiante: studentFullName(p.Estudiante ?? {}) || '—',
+        codigoPersona: cleanStr(p.Estudiante?.Codigo_persona),
+        concepto: cleanStr(p.Nombre_producto),
+        periodo: cleanStr(p.Nombre_periodo),
+        saldo: Number(p.Valor_saldo) || 0,
+        total: Number(p.Valor_total) || 0,
+        pagado: Number(p.Valor_pagado) || 0,
+      }));
+
+    const revenueByConcept = groupSum(pagos, (p) =>
+      cleanStr(p.Nombre_programa) || 'Sin programa',
+      'Valor_pagado',
+    );
+
+    const recentPayments = pagos
+      .slice()
+      .sort((a, b) => {
+        const da = parseDate(a.Fecha_pago)?.getTime() ?? 0;
+        const db = parseDate(b.Fecha_pago)?.getTime() ?? 0;
+        return db - da;
+      })
+      .slice(0, 15)
+      .map((p) => ({
+        fecha: cleanStr(p.Fecha_pago).slice(0, 10),
+        estudiante: cleanStr(p.Nombre_estudiante),
+        identificacion: cleanStr(p.Identificacion_estudiante),
+        valor: Number(p.Valor_pagado) || 0,
+        recibo: cleanStr(p.Numero_recibo_pago),
+      }));
+
+    return {
+      generatedAt: new Date().toISOString(),
+      partial: Object.keys(errors).length > 0,
+      errors,
+      degraded,
+      summary: {
+        monthsBack,
+        totalRevenue,
+        outstandingDebt,
+        payingStudents: payingTotals.length,
+        activeWithDebt,
+        inadimplenciaRate,
+        projectionRate,
+        avgTicket: Math.round(avgTicket * 100) / 100,
+        ltvApprox: Math.round(ltvApprox * 100) / 100,
+        maxPaid,
+      },
+      charts: {
+        revenueByMonth: revenueSeries,
+        revenueByConcept,
+      },
+      tables: {
+        topDebtors,
+        recentPayments,
+      },
+    };
+  }
+}

--- a/src/q10/dashboard/helpers.ts
+++ b/src/q10/dashboard/helpers.ts
@@ -1,0 +1,143 @@
+/**
+ * Shared utilities for the four dashboard services (overview, academic,
+ * financial, commercial). Kept as pure functions so the services stay
+ * testable without dependency-injection gymnastics.
+ */
+
+export type Item = Record<string, any>;
+
+export function safeArray(v: unknown): Item[] {
+  if (Array.isArray(v)) return v as Item[];
+  if (v && typeof v === 'object') {
+    const maybeList = (v as any).items ?? (v as any).data ?? (v as any).results;
+    if (Array.isArray(maybeList)) return maybeList;
+  }
+  return [];
+}
+
+export function parseDate(value: unknown): Date | null {
+  if (!value || typeof value !== 'string') return null;
+  const d = new Date(value);
+  return isNaN(d.getTime()) ? null : d;
+}
+
+/** Trim + treat literal "null" strings as empty (Q10 does that sometimes). */
+export function cleanStr(v: unknown): string {
+  if (v == null) return '';
+  const s = String(v).trim();
+  return s === 'null' ? '' : s;
+}
+
+/** Q10 serialises booleans as the literal string "true"/"false" sometimes. */
+export function isActivo(status: unknown): boolean {
+  if (status === true) return true;
+  const s = cleanStr(status).toLowerCase();
+  return s === 'true' || s.includes('activ');
+}
+
+export function sum(list: Item[], field: string): number {
+  return list.reduce((acc, x) => acc + (Number(x[field]) || 0), 0);
+}
+
+export function groupCount<T extends Item>(
+  list: T[],
+  getter: (item: T) => unknown,
+): Record<string, number> {
+  const out: Record<string, number> = {};
+  for (const item of list) {
+    const key = cleanStr(getter(item)) || 'Sin especificar';
+    out[key] = (out[key] ?? 0) + 1;
+  }
+  return out;
+}
+
+export function groupSum<T extends Item>(
+  list: T[],
+  keyGetter: (item: T) => unknown,
+  valueField: string,
+): Record<string, number> {
+  const out: Record<string, number> = {};
+  for (const item of list) {
+    const key = cleanStr(keyGetter(item)) || 'Sin especificar';
+    const v = Number(item[valueField]) || 0;
+    out[key] = (out[key] ?? 0) + v;
+  }
+  return out;
+}
+
+/** Pick periods considered "active right now" — Estado=Activo AND today is
+ *  within Fecha_inicio..Fecha_fin. Falls back to all active if none contains
+ *  today (e.g. between-term gaps). */
+export function currentlyActivePeriods(periodos: Item[]): Item[] {
+  const now = Date.now();
+  const active = periodos.filter((p) => isActivo(p.Estado));
+  const current = active.filter((p) => {
+    const start = parseDate(p.Fecha_inicio)?.getTime() ?? -Infinity;
+    const end = parseDate(p.Fecha_fin)?.getTime() ?? Infinity;
+    return now >= start && now <= end;
+  });
+  return current.length > 0 ? current : active;
+}
+
+/** The most recent period (by Fecha_fin) that isn't in `active`. Used as the
+ *  "previous" reference for retention/churn comparisons. */
+export function previousPeriod(periodos: Item[], active: Item[]): Item | null {
+  const activeConsecutivos = new Set(active.map((p) => cleanStr(p.Consecutivo)));
+  const candidates = periodos.filter((p) => !activeConsecutivos.has(cleanStr(p.Consecutivo)));
+  if (!candidates.length) return null;
+  return candidates.sort((a, b) => {
+    const ea = parseDate(a.Fecha_fin)?.getTime() ?? 0;
+    const eb = parseDate(b.Fecha_fin)?.getTime() ?? 0;
+    return eb - ea;
+  })[0];
+}
+
+export function periodKey(p: Item): string {
+  return (
+    cleanStr(p.Consecutivo) ||
+    cleanStr(p.Consecutivo_periodo) ||
+    cleanStr(p.Codigo) ||
+    cleanStr(p.Id)
+  );
+}
+
+/** Assemble a full name from Q10's split fields. /pagosPendientes nests the
+ *  student under `Estudiante` with a pre-joined `Nombre_completo` — we prefer
+ *  that when present. */
+export function studentFullName(s: Item): string {
+  const joined = cleanStr(s.Nombre_completo);
+  if (joined) return joined;
+  return [s.Primer_nombre, s.Segundo_nombre, s.Primer_apellido, s.Segundo_apellido]
+    .map(cleanStr)
+    .filter(Boolean)
+    .join(' ');
+}
+
+export function isoDate(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}
+
+export function monthKey(d: Date): string {
+  return d.toISOString().slice(0, 7);
+}
+
+/** Compute age from Fecha_nacimiento (YYYY-MM-DD or ISO). Returns null for
+ *  unparseable input. */
+export function ageFromBirthdate(value: unknown): number | null {
+  const d = parseDate(value);
+  if (!d) return null;
+  const diff = Date.now() - d.getTime();
+  const years = diff / (1000 * 60 * 60 * 24 * 365.25);
+  if (years < 0 || years > 120) return null;
+  return Math.floor(years);
+}
+
+export function ageBucket(age: number): string {
+  if (age < 12) return '<12';
+  if (age < 18) return '12-17';
+  if (age < 25) return '18-24';
+  if (age < 35) return '25-34';
+  if (age < 50) return '35-49';
+  if (age < 65) return '50-64';
+  return '65+';
+}

--- a/src/q10/dashboard/helpers.ts
+++ b/src/q10/dashboard/helpers.ts
@@ -28,11 +28,16 @@ export function cleanStr(v: unknown): string {
   return s === 'null' ? '' : s;
 }
 
-/** Q10 serialises booleans as the literal string "true"/"false" sometimes. */
+/**
+ * Q10 serialises status as boolean true OR the literal strings "true"/
+ * "Activo"/"Active" (mixed casing). We match against an explicit set so
+ * `"inactive"`/`"inactivo"` don't sneak through a substring check (review
+ * #7 finding).
+ */
+const ACTIVO_VALUES = new Set(['true', 'activo', 'active', '1']);
 export function isActivo(status: unknown): boolean {
   if (status === true) return true;
-  const s = cleanStr(status).toLowerCase();
-  return s === 'true' || s.includes('activ');
+  return ACTIVO_VALUES.has(cleanStr(status).toLowerCase());
 }
 
 export function sum(list: Item[], field: string): number {

--- a/src/q10/enrollment.service.ts
+++ b/src/q10/enrollment.service.ts
@@ -10,6 +10,20 @@ type StepResult = { step: number; name: string; status: 'ok' | 'reused'; id?: st
 export class EnrollmentService {
   private readonly logger = new Logger(EnrollmentService.name);
 
+  /**
+   * Per-`ref` in-flight promise map. Two concurrent POST /api/q10/enrollment
+   * requests with the same `ref` would otherwise both see `tracking.get(ref)`
+   * return null, race past the idempotency check and POST /contactos twice
+   * to Q10 — a real TOCTOU pointed out in review #7.
+   *
+   * Limitation: this only protects within one Node process. On a
+   * multi-instance deploy we would need either a SQLite `BEGIN IMMEDIATE`
+   * transaction around the claim or a Redis/Postgres advisory lock. The
+   * current Coolify deploy is single-container, so this is enough today,
+   * and the limitation is documented inline so we don't forget when scaling.
+   */
+  private readonly inFlight = new Map<string, Promise<unknown>>();
+
   constructor(
     private readonly q10: Q10ClientService,
     private readonly tracking: TrackingService,
@@ -23,15 +37,48 @@ export class EnrollmentService {
    */
   async run(req: EnrollmentDto) {
     const ref = req.ref ?? `ENR-${randomUUID().slice(0, 8).toUpperCase()}`;
-    const existing = await this.tracking.get(ref);
+
+    // Serialize concurrent same-ref requests. The first caller starts the
+    // workflow; subsequent callers await the same promise and receive the
+    // same response (they won't trigger a second set of Q10 POSTs).
+    const existing = this.inFlight.get(ref);
+    if (existing) return existing as ReturnType<typeof this.runInternal>;
+
+    const p = this.runInternal(ref, req).finally(() => this.inFlight.delete(ref));
+    this.inFlight.set(ref, p);
+    return p;
+  }
+
+  private async runInternal(ref: string, req: EnrollmentDto) {
+    // Fast path: if a previous completed run already has an orderId,
+    // return it without touching Q10 again. The public response shape
+    // stays stable so retries from the form look identical to the first
+    // submission.
+    const prior = await this.tracking.get(ref);
+    if (prior?.status === 'filled' && prior.paymentOrderId) {
+      this.logger.log(`[enrollment:${ref}] returning cached result (status=filled)`);
+      return {
+        success: true as const,
+        ref,
+        status: 'filled' as const,
+        message: 'Enrollment already completed',
+        paymentDetails: {
+          orderId: prior.paymentOrderId,
+          amount: req.payment?.Valor ?? 0,
+          concept: req.payment?.Concepto_pago ?? 'Matrícula',
+          dueDate: req.payment?.Fecha_vencimiento ?? '',
+        },
+      };
+    }
+
     const steps: StepResult[] = [];
 
     // Reuse IDs from a previous partial run so retries don't duplicate records.
-    let contactId = existing?.contactId;
-    let studentId = existing?.studentId;
-    let enrollmentId = existing?.enrollmentId;
-    let matriculaId = existing?.matriculaId;
-    let paymentOrderId = existing?.paymentOrderId;
+    let contactId = prior?.contactId;
+    let studentId = prior?.studentId;
+    let enrollmentId = prior?.enrollmentId;
+    let matriculaId = prior?.matriculaId;
+    let paymentOrderId = prior?.paymentOrderId;
 
     try {
       // ── Step 1: Contact ──

--- a/src/q10/enrollment.service.ts
+++ b/src/q10/enrollment.service.ts
@@ -23,7 +23,7 @@ export class EnrollmentService {
    */
   async run(req: EnrollmentDto) {
     const ref = req.ref ?? `ENR-${randomUUID().slice(0, 8).toUpperCase()}`;
-    const existing = this.tracking.get(ref);
+    const existing = await this.tracking.get(ref);
     const steps: StepResult[] = [];
 
     // Reuse IDs from a previous partial run so retries don't duplicate records.
@@ -49,7 +49,7 @@ export class EnrollmentService {
         });
         contactId = contact?.Codigo_contacto ?? contact?.Codigo ?? contact?.Id ?? contact?.id;
         steps.push({ step: 1, name: 'contact', status: 'ok', id: contactId });
-        this.persist(ref, req, { contactId }, steps);
+        await this.persist(ref, req, { contactId }, steps);
         this.logger.log(`[enrollment:${ref}] contact ${contactId}`);
       }
 
@@ -71,7 +71,7 @@ export class EnrollmentService {
         });
         studentId = student?.Codigo_estudiante ?? student?.Codigo ?? student?.Id ?? student?.id;
         steps.push({ step: 2, name: 'student', status: 'ok', id: studentId });
-        this.persist(ref, req, { contactId, studentId }, steps);
+        await this.persist(ref, req, { contactId, studentId }, steps);
         this.logger.log(`[enrollment:${ref}] student ${studentId}`);
       }
 
@@ -87,7 +87,7 @@ export class EnrollmentService {
         });
         enrollmentId = inscripcion?.Codigo_inscripcion ?? inscripcion?.Codigo ?? inscripcion?.Id;
         steps.push({ step: 3, name: 'enrollment', status: 'ok', id: enrollmentId });
-        this.persist(ref, req, { contactId, studentId, enrollmentId }, steps);
+        await this.persist(ref, req, { contactId, studentId, enrollmentId }, steps);
         this.logger.log(`[enrollment:${ref}] inscripcion ${enrollmentId}`);
       }
 
@@ -104,7 +104,7 @@ export class EnrollmentService {
         });
         matriculaId = matricula?.Codigo_matricula ?? matricula?.Codigo ?? matricula?.Id;
         steps.push({ step: 4, name: 'matricula', status: 'ok', id: matriculaId });
-        this.persist(ref, req, { contactId, studentId, enrollmentId, matriculaId }, steps);
+        await this.persist(ref, req, { contactId, studentId, enrollmentId, matriculaId }, steps);
         this.logger.log(`[enrollment:${ref}] matricula ${matriculaId}`);
       }
 
@@ -125,7 +125,7 @@ export class EnrollmentService {
         this.logger.log(`[enrollment:${ref}] orden ${paymentOrderId}`);
       }
 
-      this.tracking.upsert({
+      await this.tracking.upsert({
         ref,
         status: 'filled',
         asesor: req.asesor ?? null,
@@ -139,19 +139,20 @@ export class EnrollmentService {
         completedSteps: steps,
       });
 
+      // Redacted response for the public form: only what the matrícula UI
+      // actually renders. The full step-by-step trace + every Q10 ID
+      // remains queryable through the admin tracking endpoint
+      // (GET /api/q10/tracking, JWT-guarded). Public response intentionally
+      // omits `ids`, `steps` and any internal Q10 identifier — review #7
+      // raised this as a privacy / surface-area concern.
       return {
         success: true,
         ref,
+        status: 'filled' as const,
         message: 'Enrollment completed successfully',
-        ids: {
-          contact: contactId,
-          student: studentId,
-          enrollment: enrollmentId,
-          matricula: matriculaId,
-          paymentOrder: paymentOrderId,
-        },
-        steps,
         paymentDetails: {
+          // The orderId stays visible because the form prints it back to the
+          // student as a payment reference number — they need it to pay.
           orderId: paymentOrderId,
           amount: req.payment?.Valor ?? 0,
           concept: req.payment?.Concepto_pago ?? 'Matrícula',
@@ -164,7 +165,7 @@ export class EnrollmentService {
       const message = err instanceof Error ? err.message : 'Unknown error';
       this.logger.error(`[enrollment:${ref}] failed at step ${failedStep}: ${message}`);
 
-      this.tracking.upsert({
+      await this.tracking.upsert({
         ref,
         status: 'error',
         asesor: req.asesor ?? null,
@@ -181,21 +182,24 @@ export class EnrollmentService {
       });
 
       if (err instanceof HttpException) throw err;
+      // Public-facing failure response, redacted for the same reason as
+      // the success path: no Q10 IDs, no step-by-step trace, no
+      // partial-progress list. The full diagnostic stays in the tracking
+      // record (admin-only).
       throw new HttpException(
         {
           success: false,
           ref,
-          error: message,
+          status: 'error' as const,
+          message: 'Hubo un problema procesando la matrícula. Por favor intenta nuevamente con la misma referencia.',
           failedStep,
-          completedSteps: steps,
-          partialIds: { contactId, studentId, enrollmentId, matriculaId, paymentOrderId },
         },
         502,
       );
     }
   }
 
-  private persist(
+  private async persist(
     ref: string,
     req: EnrollmentDto,
     ids: {
@@ -206,8 +210,8 @@ export class EnrollmentService {
       paymentOrderId?: string;
     },
     steps: StepResult[],
-  ) {
-    this.tracking.upsert({
+  ): Promise<void> {
+    await this.tracking.upsert({
       ref,
       status: 'opened',
       asesor: req.asesor ?? null,

--- a/src/q10/q10.controller.ts
+++ b/src/q10/q10.controller.ts
@@ -72,8 +72,8 @@ export class Q10PublicController {
   }
 
   @Post('tracking')
-  upsertTracking(@Body() body: PublicUpsertTrackingDto) {
-    const entry = this.tracking.upsert({
+  async upsertTracking(@Body() body: PublicUpsertTrackingDto) {
+    const entry = await this.tracking.upsert({
       ref: body.ref,
       status: body.status ?? 'opened',
       asesor: body.asesor,
@@ -94,8 +94,8 @@ export class Q10PublicController {
    * details, or the list of completed steps — those are admin-only.
    */
   @Get('tracking/:ref')
-  getTracking(@Param('ref') ref: string) {
-    const entry = this.tracking.get(ref);
+  async getTracking(@Param('ref') ref: string) {
+    const entry = await this.tracking.get(ref);
     if (!entry) {
       return {
         ref,
@@ -133,8 +133,8 @@ export class Q10AdminController {
 
   // ─────────── Tracking list (audit) ───────────
   @Get('tracking')
-  listTracking() {
-    const entries = this.tracking.list();
+  async listTracking() {
+    const entries = await this.tracking.list();
     return { count: entries.length, entries };
   }
 

--- a/src/q10/q10.module.ts
+++ b/src/q10/q10.module.ts
@@ -1,5 +1,8 @@
 import { Module } from '@nestjs/common';
 import { AuthModule } from '../auth/auth.module';
+import { AcademicService } from './dashboard/academic.service';
+import { CommercialService } from './dashboard/commercial.service';
+import { FinancialService } from './dashboard/financial.service';
 import { DashboardController } from './dashboard.controller';
 import { DashboardService } from './dashboard.service';
 import { EnrollmentService } from './enrollment.service';
@@ -17,6 +20,9 @@ import { TrackingService } from './tracking.service';
     TrackingService,
     EnrollmentService,
     DashboardService,
+    AcademicService,
+    FinancialService,
+    CommercialService,
   ],
   exports: [Q10ClientService, TrackingService],
 })

--- a/src/q10/q10.module.ts
+++ b/src/q10/q10.module.ts
@@ -1,4 +1,5 @@
 import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
 import { AuthModule } from '../auth/auth.module';
 import { AcademicService } from './dashboard/academic.service';
 import { CommercialService } from './dashboard/commercial.service';
@@ -9,10 +10,11 @@ import { EnrollmentService } from './enrollment.service';
 import { Q10ClientService } from './q10-client.service';
 import { Q10MockService } from './q10-mock.service';
 import { Q10AdminController, Q10PublicController } from './q10.controller';
+import { TrackingEntryEntity } from './tracking-entry.entity';
 import { TrackingService } from './tracking.service';
 
 @Module({
-  imports: [AuthModule],
+  imports: [AuthModule, TypeOrmModule.forFeature([TrackingEntryEntity])],
   controllers: [DashboardController, Q10PublicController, Q10AdminController],
   providers: [
     Q10ClientService,

--- a/src/q10/tracking-entry.entity.ts
+++ b/src/q10/tracking-entry.entity.ts
@@ -1,0 +1,67 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  PrimaryColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+
+/**
+ * Persistent tracking record for the matrícula form. The IDs returned by
+ * the Q10 ERP at each step of the enrollment workflow are stored here so
+ * that a retry — even after a server restart, redeploy or instance swap —
+ * can detect partial progress and skip the steps that already succeeded.
+ *
+ * Without this, an enrollment that crashed midway between step 3 and 4
+ * would create duplicate contacts/students/inscripciones in Q10 the next
+ * time someone clicked "Submit" on the same `ref`.
+ */
+@Entity('tracking_entries')
+export class TrackingEntryEntity {
+  @PrimaryColumn()
+  ref: string;
+
+  @Column({ default: 'pending' })
+  status: string;
+
+  @Column({ type: 'varchar', nullable: true })
+  asesor: string | null;
+
+  @Column({ type: 'varchar', nullable: true })
+  studentName: string | null;
+
+  @Column({ type: 'varchar', nullable: true })
+  email: string | null;
+
+  @Column({ type: 'varchar', nullable: true })
+  contactId: string | null;
+
+  @Column({ type: 'varchar', nullable: true })
+  studentId: string | null;
+
+  @Column({ type: 'varchar', nullable: true })
+  enrollmentId: string | null;
+
+  @Column({ type: 'varchar', nullable: true })
+  matriculaId: string | null;
+
+  @Column({ type: 'varchar', nullable: true })
+  paymentOrderId: string | null;
+
+  @Column({ type: 'varchar', nullable: true })
+  error: string | null;
+
+  @Column({ type: 'int', nullable: true })
+  failedStep: number | null;
+
+  // Stored as JSON string — the steps array is a small structured log of
+  // what executed/reused on the most recent attempt.
+  @Column({ type: 'text', nullable: true })
+  completedStepsJson: string | null;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/src/q10/tracking.service.ts
+++ b/src/q10/tracking.service.ts
@@ -1,4 +1,7 @@
 import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { TrackingEntryEntity } from './tracking-entry.entity';
 
 export type TrackingStatus = 'pending' | 'opened' | 'filled' | 'paid' | 'error';
 
@@ -21,44 +24,84 @@ export interface TrackingEntry {
 }
 
 /**
- * In-memory tracking store for the enrollment form.
+ * Persistent tracking store backed by SQLite via TypeORM. Replaces the
+ * previous in-memory `Map`, which lost state on every restart and made
+ * enrollment retries non-idempotent across deploys (review feedback).
  *
- * When the backend scales beyond a single instance we should migrate this to
- * the SQLite DB (same schema, drop-in repository replacement).
+ * Every value goes through string normalisation so JSON-stored
+ * `completedSteps` round-trip cleanly.
  */
 @Injectable()
 export class TrackingService {
-  private readonly store = new Map<string, TrackingEntry>();
+  constructor(
+    @InjectRepository(TrackingEntryEntity)
+    private readonly repo: Repository<TrackingEntryEntity>,
+  ) {}
 
-  get(ref: string): TrackingEntry | null {
-    return this.store.get(ref) ?? null;
+  async get(ref: string): Promise<TrackingEntry | null> {
+    const row = await this.repo.findOne({ where: { ref } });
+    return row ? this.toDomain(row) : null;
   }
 
-  upsert(partial: Partial<TrackingEntry> & { ref: string }): TrackingEntry {
-    const existing = this.store.get(partial.ref);
-    const now = new Date().toISOString();
-    const entry: TrackingEntry = {
+  async upsert(partial: Partial<TrackingEntry> & { ref: string }): Promise<TrackingEntry> {
+    const existing = await this.repo.findOne({ where: { ref: partial.ref } });
+    const merged: Partial<TrackingEntryEntity> = {
       ref: partial.ref,
       status: partial.status ?? existing?.status ?? 'pending',
-      asesor: partial.asesor ?? existing?.asesor ?? null,
-      studentName: partial.studentName ?? existing?.studentName ?? null,
-      email: partial.email ?? existing?.email ?? null,
-      contactId: partial.contactId ?? existing?.contactId,
-      studentId: partial.studentId ?? existing?.studentId,
-      enrollmentId: partial.enrollmentId ?? existing?.enrollmentId,
-      matriculaId: partial.matriculaId ?? existing?.matriculaId,
-      paymentOrderId: partial.paymentOrderId ?? existing?.paymentOrderId,
-      error: partial.error ?? existing?.error,
-      failedStep: partial.failedStep ?? existing?.failedStep,
-      completedSteps: partial.completedSteps ?? existing?.completedSteps,
-      createdAt: existing?.createdAt ?? now,
-      updatedAt: now,
+      asesor: nullable(partial.asesor ?? existing?.asesor ?? null),
+      studentName: nullable(partial.studentName ?? existing?.studentName ?? null),
+      email: nullable(partial.email ?? existing?.email ?? null),
+      contactId: nullable(partial.contactId ?? existing?.contactId ?? null),
+      studentId: nullable(partial.studentId ?? existing?.studentId ?? null),
+      enrollmentId: nullable(partial.enrollmentId ?? existing?.enrollmentId ?? null),
+      matriculaId: nullable(partial.matriculaId ?? existing?.matriculaId ?? null),
+      paymentOrderId: nullable(partial.paymentOrderId ?? existing?.paymentOrderId ?? null),
+      error: nullable(partial.error ?? existing?.error ?? null),
+      failedStep: partial.failedStep ?? existing?.failedStep ?? null,
+      completedStepsJson: partial.completedSteps !== undefined
+        ? JSON.stringify(partial.completedSteps)
+        : (existing?.completedStepsJson ?? null),
     };
-    this.store.set(partial.ref, entry);
-    return entry;
+    const entity = this.repo.create(merged);
+    await this.repo.save(entity);
+    // Re-fetch after save so the @CreateDateColumn / @UpdateDateColumn
+    // defaults populated by SQLite are visible. better-sqlite3 doesn't
+    // back-fill these on the in-memory entity returned by `save`.
+    const fresh = await this.repo.findOneByOrFail({ ref: partial.ref });
+    return this.toDomain(fresh);
   }
 
-  list(): TrackingEntry[] {
-    return Array.from(this.store.values());
+  async list(): Promise<TrackingEntry[]> {
+    const rows = await this.repo.find({ order: { updatedAt: 'DESC' } });
+    return rows.map((r) => this.toDomain(r));
   }
+
+  private toDomain(row: TrackingEntryEntity): TrackingEntry {
+    let completedSteps: unknown[] | undefined;
+    if (row.completedStepsJson) {
+      try { completedSteps = JSON.parse(row.completedStepsJson); }
+      catch { completedSteps = undefined; }
+    }
+    return {
+      ref: row.ref,
+      status: row.status as TrackingStatus,
+      asesor: row.asesor,
+      studentName: row.studentName,
+      email: row.email,
+      contactId: row.contactId ?? undefined,
+      studentId: row.studentId ?? undefined,
+      enrollmentId: row.enrollmentId ?? undefined,
+      matriculaId: row.matriculaId ?? undefined,
+      paymentOrderId: row.paymentOrderId ?? undefined,
+      error: row.error ?? undefined,
+      failedStep: row.failedStep ?? undefined,
+      completedSteps,
+      createdAt: row.createdAt.toISOString(),
+      updatedAt: row.updatedAt.toISOString(),
+    };
+  }
+}
+
+function nullable<T>(v: T | undefined | null): T | null {
+  return v == null ? null : v;
 }

--- a/test/dashboard-tabs.e2e-spec.ts
+++ b/test/dashboard-tabs.e2e-spec.ts
@@ -1,0 +1,113 @@
+import { INestApplication } from '@nestjs/common';
+import request = require('supertest');
+import { createTestApp, loginAsAdmin } from './helpers/app';
+
+/**
+ * Smoke tests for the three sibling dashboard tabs that landed alongside
+ * the multi-tab UI. Each endpoint should require authentication, return
+ * 200 with the documented shape, and not throw on the mock dataset.
+ */
+describe('Dashboard tabs — academic / financial / commercial', () => {
+  let app: INestApplication;
+  let cookie: string;
+
+  beforeAll(async () => {
+    app = await createTestApp();
+    cookie = await loginAsAdmin(app);
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it.each([
+    ['/api/dashboard/academic'],
+    ['/api/dashboard/financial'],
+    ['/api/dashboard/commercial'],
+  ])('%s requires a session cookie', async (path) => {
+    await request(app.getHttpServer()).get(path).expect(401);
+  });
+
+  it('GET /api/dashboard/academic returns composition + retention shape', async () => {
+    const resp = await request(app.getHttpServer())
+      .get('/api/dashboard/academic')
+      .set('Cookie', cookie)
+      .expect(200);
+
+    expect(resp.body.summary).toEqual(
+      expect.objectContaining({
+        totalStudents: expect.any(Number),
+        totalTeachers: expect.any(Number),
+      }),
+    );
+    expect(resp.body.retention).toEqual(
+      expect.objectContaining({
+        previousTotal: expect.any(Number),
+        currentTotal: expect.any(Number),
+        retained: expect.any(Number),
+        churned: expect.any(Number),
+        newcomers: expect.any(Number),
+      }),
+    );
+    expect(resp.body.distributions).toEqual(
+      expect.objectContaining({
+        byJornada: expect.any(Object),
+        byNivel: expect.any(Object),
+        byGender: expect.any(Object),
+        byAge: expect.any(Object),
+      }),
+    );
+    expect(Array.isArray(resp.body.teachers)).toBe(true);
+  });
+
+  it('GET /api/dashboard/financial returns MRR series + debt tables', async () => {
+    const resp = await request(app.getHttpServer())
+      .get('/api/dashboard/financial?months=6')
+      .set('Cookie', cookie)
+      .expect(200);
+
+    expect(resp.body.summary).toEqual(
+      expect.objectContaining({
+        monthsBack: 6,
+        totalRevenue: expect.any(Number),
+        outstandingDebt: expect.any(Number),
+        payingStudents: expect.any(Number),
+      }),
+    );
+    expect(Array.isArray(resp.body.charts.revenueByMonth)).toBe(true);
+    // 6 months requested → 6 buckets.
+    expect(resp.body.charts.revenueByMonth).toHaveLength(6);
+    expect(Array.isArray(resp.body.tables.topDebtors)).toBe(true);
+    expect(Array.isArray(resp.body.tables.recentPayments)).toBe(true);
+  });
+
+  it('GET /api/dashboard/financial clamps the months parameter to a safe range', async () => {
+    const resp = await request(app.getHttpServer())
+      .get('/api/dashboard/financial?months=9999')
+      .set('Cookie', cookie)
+      .expect(200);
+    // Controller enforces max 60 to keep the Q10 page-size within bounds.
+    expect(resp.body.summary.monthsBack).toBe(60);
+  });
+
+  it('GET /api/dashboard/commercial returns funnel states + advisors', async () => {
+    const resp = await request(app.getHttpServer())
+      .get('/api/dashboard/commercial')
+      .set('Cookie', cookie)
+      .expect(200);
+
+    expect(resp.body.summary).toEqual(
+      expect.objectContaining({
+        totalOpportunities: expect.any(Number),
+        won: expect.any(Number),
+        lost: expect.any(Number),
+        inProgress: expect.any(Number),
+      }),
+    );
+    expect(Array.isArray(resp.body.charts.leadsByMonth)).toBe(true);
+    expect(resp.body.charts.leadsByMonth).toHaveLength(12);
+    expect(Array.isArray(resp.body.tables.advisors)).toBe(true);
+    expect(Array.isArray(resp.body.tables.topMunicipios)).toBe(true);
+    expect(Array.isArray(resp.body.tables.recentOpps)).toBe(true);
+  });
+});

--- a/test/dashboard.e2e-spec.ts
+++ b/test/dashboard.e2e-spec.ts
@@ -49,18 +49,22 @@ describe('GET /api/dashboard/overview — partial state (#5 round 2)', () => {
 
     expect(resp.body.partial).toBe(true);
     expect(resp.body.errors).toMatchObject({
-      // DashboardService no longer calls /ordenespago, /pagos, /pagospendientes
-      // (they don't apply to this Q10 plan). The sources that DO run and fail
-      // when the client rejects everything are /periodos, /contactos,
-      // /oportunidades, /negocios, and /estadocuentaestudiantes.
+      // After the live-diagnostic fix, DashboardService only calls endpoints
+      // confirmed to work on the "pagos regulares" plan: /periodos,
+      // /contactos, /oportunidades, /pagos. /negocios and
+      // /estadocuentaestudiantes are dropped (400 in every param combo),
+      // and /estudiantes + /pagosPendientes only fire after /periodos
+      // returns at least one active period — so with /periodos rejecting
+      // here, they don't generate their own error entries.
       periods: expect.any(String),
       contacts: expect.any(String),
       opportunities: expect.any(String),
-      deals: expect.any(String),
-      estadoCuenta: expect.any(String),
+      payments: expect.any(String),
     });
     // KPIs still come back (zeros), so the frontend has something to render.
     expect(resp.body.kpis.activeStudents).toBe(0);
+    // When periods failed, students list is degraded — UI surfaces that.
+    expect(resp.body.degraded).toHaveProperty('students');
   });
 
   it('returns partial:false when all sources succeed', async () => {

--- a/test/dashboard.e2e-spec.ts
+++ b/test/dashboard.e2e-spec.ts
@@ -89,5 +89,14 @@ describe('GET /api/dashboard/overview — partial state (#5 round 2)', () => {
 
     expect(resp.body.partial).toBe(false);
     expect(resp.body.errors).toEqual({});
+    // overduePending is degraded by design on this Q10 plan — /pagosPendientes
+    // does not expose Fecha_vencimiento. Keep this assertion so a future
+    // schema change that re-enables the field gets caught.
+    expect(resp.body.degraded.overduePending).toBeTruthy();
+    // Conversion rate degradation is data-driven (depends on opps vs students
+    // ratio). With the small mock dataset the CRM is "underused", so the
+    // backend marks conversionRate as degraded → null.
+    expect(resp.body.kpis.conversionRate).toBeNull();
+    expect(resp.body.degraded.conversionRate).toBeTruthy();
   });
 });

--- a/test/enrollment.e2e-spec.ts
+++ b/test/enrollment.e2e-spec.ts
@@ -97,7 +97,30 @@ describe('POST /api/q10/enrollment — DTO + idempotency (#2 / #3)', () => {
     expect(resp.body.ref).toBe('ENR-GOODREF1');
   });
 
-  it('replaying with same ref reuses IDs and skips upstream POSTs', async () => {
+  // Per review #7: enrollment idempotency must survive a backend restart.
+  // We can't actually kill+restart Nest mid-test, but we can prove the
+  // tracking entry persisted in SQLite is what carries the IDs across by
+  // re-reading it through a fresh service instance after the first run.
+  it('persists tracking in SQLite (survives a fresh service instance)', async () => {
+    const ref = 'ENR-RESTART01';
+    await request(app.getHttpServer())
+      .post('/api/q10/enrollment')
+      .send({ ref, personal: VALID_PERSONAL, program: VALID_PROGRAM })
+      .expect(201);
+
+    // Resolve the TrackingService via the Nest container — same SQLite
+    // file but a fresh function call simulates "what the next request,
+    // possibly served by a different process instance, would see".
+    const trackingSvc = app.get(require('../src/q10/tracking.service').TrackingService);
+    const entry = await trackingSvc.get(ref);
+    expect(entry).not.toBeNull();
+    expect(entry.contactId).toBeTruthy();
+    expect(entry.studentId).toBeTruthy();
+    expect(entry.paymentOrderId).toBeTruthy();
+    expect(entry.status).toBe('filled');
+  });
+
+  it('replaying with same ref does not duplicate (idempotent) — first run + replay return identical paymentDetails.orderId', async () => {
     const ref = `ENR-IDEMP${Date.now()}TEST`.replace(/-/g, '').replace(
       /^/,
       'ENR-',
@@ -111,14 +134,25 @@ describe('POST /api/q10/enrollment — DTO + idempotency (#2 / #3)', () => {
 
     expect(first.body.success).toBe(true);
     expect(first.body.ref).toBe(ref);
-    expect(first.body.steps.every((s: any) => s.status === 'ok')).toBe(true);
+    expect(first.body.status).toBe('filled');
+    // The redacted public response must NOT leak the per-step trace or
+    // any raw Q10 IDs (review #7 finding). Only `paymentDetails.orderId`
+    // is intentionally exposed because the form prints it as the user's
+    // payment reference.
+    expect(first.body).not.toHaveProperty('ids');
+    expect(first.body).not.toHaveProperty('steps');
+    expect(first.body).not.toHaveProperty('partialIds');
+    expect(first.body.paymentDetails).toHaveProperty('orderId');
 
     const replay = await request(app.getHttpServer())
       .post('/api/q10/enrollment')
       .send(body)
       .expect(201);
 
-    expect(replay.body.ids).toEqual(first.body.ids);
-    expect(replay.body.steps.every((s: any) => s.status === 'reused')).toBe(true);
+    expect(replay.body.ref).toBe(ref);
+    // Same orderId on retry proves the workflow reused the previously-stored
+    // IDs (idempotency through the persistent tracking store) instead of
+    // creating a fresh Q10 row for the order.
+    expect(replay.body.paymentDetails.orderId).toBe(first.body.paymentDetails.orderId);
   });
 });

--- a/test/enrollment.e2e-spec.ts
+++ b/test/enrollment.e2e-spec.ts
@@ -120,6 +120,31 @@ describe('POST /api/q10/enrollment — DTO + idempotency (#2 / #3)', () => {
     expect(entry.status).toBe('filled');
   });
 
+  // Per review #7: five concurrent POSTs with the same `ref` must NOT
+  // create five Q10 contacts. The per-ref mutex in EnrollmentService
+  // serialises them; only the first one actually hits Q10, the rest
+  // await and return the identical response.
+  it('serialises concurrent same-ref requests (no TOCTOU duplicate)', async () => {
+    const ref = 'ENR-CONCURR01';
+    const body = { ref, personal: VALID_PERSONAL, program: VALID_PROGRAM };
+
+    const responses = await Promise.all(
+      Array.from({ length: 5 }).map(() =>
+        request(app.getHttpServer())
+          .post('/api/q10/enrollment')
+          .send(body)
+          .expect(201),
+      ),
+    );
+
+    const orderIds = responses.map((r) => r.body.paymentDetails.orderId);
+    // All five callers must see exactly the same orderId — proves we
+    // created exactly one orden de pago in Q10, not five.
+    const unique = new Set(orderIds);
+    expect(unique.size).toBe(1);
+    expect(orderIds[0]).toBeTruthy();
+  });
+
   it('replaying with same ref does not duplicate (idempotent) — first run + replay return identical paymentDetails.orderId', async () => {
     const ref = `ENR-IDEMP${Date.now()}TEST`.replace(/-/g, '').replace(
       /^/,


### PR DESCRIPTION
Two things in one PR (they share the same files):

1. **Fix field mapping** — dashboard Visión general was showing `—` / `01` / `0 activos` because the code expected `Nombres`/`Codigo_programa`/`Estado`, but Q10 returns `Primer_nombre`/`Nombre_programa`/`Condicion_matricula`. Live diagnostic against the real tenant exposed the true shapes.
2. **Multi-tab dashboard** — 3 new tabs (Académico / Financiero / Comercial) with their own deep-dive KPIs, each backed by an isolated service.

## Why tabs

Stuffing 20+ KPIs into one screen kills the "what should I do today?" glance. Tab 1 stays the executive pulse (≤8 cards). Other tabs load lazily when the director wants to dig in.

## What lands

### Backend (`src/q10/dashboard/`)

`helpers.ts` — shared pure utilities (parseDate, cleanStr, groupCount/Sum, currentlyActivePeriods, previousPeriod, studentFullName, age bucketing).

| Service | Endpoint | KPIs |
|---|---|---|
| **DashboardService** | `GET /api/dashboard/overview?range=N` | Visión general (fixed field mapping) |
| **AcademicService** | `GET /api/dashboard/academic` | Composition + retention cohort |
| **FinancialService** | `GET /api/dashboard/financial?months=N` | MRR series + debt + LTV |
| **CommercialService** | `GET /api/dashboard/commercial` | Funnel states + origins + workload |

### Académico — live dataset sanity

Uses `/estudiantes` (34 fields/record) exclusively — no endpoints this plan rejects.

- Distribution by **jornada** (Mañana/Noche/Sábado), **nivel CEFR** (A1→C2), **sede-jornada**, **programa**, **Condicion_matricula**, **gender**, **age bucket**
- **Retention cohort**: compares active-period students with the previous period's list (set intersection by `Codigo_estudiante`). Outputs `retained / churned / newcomers` + rates. Doesn't rely on `Condicion_matricula` which is `null` for all P1 records on this tenant.
- **Teachers** list (10 on the live tenant)

### Financiero — real "pagos regulares" numbers

- **MRR** monthly trend (12 months default, max 60). Live tenant: Q5 → Q201 → Q226 → Q326 → Q425 — positive trend.
- **Ticket médio** + **LTV approximation** (avg/max `Valor_pagado` per `Codigo_persona`)
- **Inadimplência** scoped to active-period students only (not lifetime)
- **Projection rate**: `sum(Valor_pagado) / sum(Valor_total)` on pending
- **Top-15 debtors** + **recent-15 payments** tables

### Comercial — will fill in as CRM is populated

- **Leads-by-month** series (12 months)
- **Funnel states** derived from `o.Negocio_favorito.Estado_negocio` (the live dump revealed this nested field — no per-opp `/negocios` calls needed, avoids N+1)
- **Origens** + channel mix, **referral index**
- **Advisor workload**, **top municipios**, **recent-15 opps**
- Today the CRM has 1 opp total on this tenant — infra is ready for when the team starts using it

### Frontend

- Sticky tab navigation under the header
- Tabs render lazily on first open; cached client-side
- Auto-refresh (60s) only refreshes the active tab — doesn't burn Q10 quota
- Range picker hidden on deep-dive tabs (not applicable there)
- New chart helpers: horizontal-bar, donut, monthly-line — Genius brand palette

## Test plan

- [x] `npm run build` clean
- [x] `npm test` — **68 tests passing** (7 new e2e for the tab endpoints)
- [x] Live diagnostic validated every field name used
- [ ] Deploy and eyeball each tab against the prod tenant

## Deferred to follow-up PRs

- **Custo por matrícula** — needs a marketing-expenses CRUD (Q10 doesn't have it)
- **Precise LTV / cohort permanência** — needs multi-year history
- **Filled CRM KPIs** — fill automatically as the team starts populating `/oportunidades`

https://claude.ai/code/session_01GJarYvsaJrh1SZPznRsiDo