### PR TITLE
build: Dockerfile Alpine → Debian slim (fixes deploy timeout)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,20 @@
 # ─── Stage 1: Build ───────────────────────────────
-# Includes native build tools so better-sqlite3 compiles successfully.
-FROM node:20-alpine AS builder
+# Debian slim instead of Alpine: better-sqlite3 ships prebuilt binaries for
+# linux-x64-glibc on Node 20, so `npm ci` here downloads the precompiled
+# `.node` artefact instead of invoking gcc/python. Build time drops from
+# ~15min (Alpine, full native compile) to ~2min on a contended VPS.
+FROM node:20-bookworm-slim AS builder
 
 WORKDIR /app
 
-RUN apk add --no-cache python3 make g++
+# Only needed if a transitive dep doesn't have a Debian prebuild and falls
+# back to source. Kept slim — full build-essential adds 200MB.
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends python3 ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
 
 COPY package*.json ./
-RUN npm ci
+RUN npm ci --no-audit --no-fund
 
 COPY . .
 RUN npm run build
@@ -16,19 +23,19 @@ RUN npm run build
 RUN npm prune --omit=dev
 
 # ─── Stage 2: Runtime ─────────────────────────────
-FROM node:20-alpine
+FROM node:20-bookworm-slim
 
 WORKDIR /app
 
-# Copy compiled app + pruned node_modules (native binaries already built).
+# Copy compiled app + pruned node_modules (native binaries already resolved).
 COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/dist ./dist
 COPY --from=builder /app/public ./public
 COPY --from=builder /app/package*.json ./
 
 # Mount a persistent volume at /app/data in Coolify so SQLite survives deploys.
-RUN addgroup -g 1001 -S nodejs && \
-    adduser -S nestjs -u 1001 && \
+RUN groupadd -r -g 1001 nodejs && \
+    useradd -r -u 1001 -g nodejs -s /usr/sbin/nologin nestjs && \
     mkdir -p /app/data && \
     chown -R nestjs:nodejs /app
 
@@ -37,10 +44,11 @@ USER nestjs
 ENV DATABASE_PATH=/app/data/genius.sqlite
 ENV PORT=3120
 ENV HOST=0.0.0.0
+ENV NODE_ENV=production
 
 EXPOSE 3120
 
-HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
   CMD node -e "require('http').get('http://localhost:3120/api/health', (r) => {process.exit(r.statusCode === 200 ? 0 : 1)})"
 
 CMD ["node", "dist/main"]


### PR DESCRIPTION
**Production hotfix** — current build hangs 10+ minutes on `apk add gcc g++` and the deploy never finishes.

## Diagnosis

VPS itself is healthy (38% disk, 11GB RAM free). The bottleneck is Alpine + `better-sqlite3`:

- `better-sqlite3` ships **no prebuilt binaries for musl libc** — Alpine forces a full source compile against `gcc/python3/make`.
- Each `apk install` step took **30–90 seconds** instead of the usual <2s — the VPS is contended (~30 colocated containers, no swap).
- `apk add gcc` alone took **9 minutes** in the failing build.

```
#7 95.79  ( 2/29) Installing jansson           ← 70s
#7 181.6  ERROR: isl26: I/O error              ← I/O thrashing
#7 693.3  (12/29) Installing musl-dev          ← 9 min for gcc
```

## Fix

Switch base image **`node:20-alpine` → `node:20-bookworm-slim`**. `better-sqlite3` has prebuilt binaries for `linux-x64-glibc + Node 20`; Debian uses glibc, so `npm ci` just downloads the `.node` file. **No gcc, no python compile.**

Expected build time: **~15min → ~2min**.

## What changed

```diff
- FROM node:20-alpine AS builder
- RUN apk add --no-cache python3 make g++
+ FROM node:20-bookworm-slim AS builder
+ RUN apt-get update && apt-get install -y --no-install-recommends python3 ca-certificates && rm -rf /var/lib/apt/lists/*

- FROM node:20-alpine
+ FROM node:20-bookworm-slim
+ ENV NODE_ENV=production    # activates assertProductionEnv() automatically

- RUN addgroup -g 1001 -S nodejs && adduser -S nestjs -u 1001
+ RUN groupadd -r -g 1001 nodejs && useradd -r -u 1001 -g nodejs -s /usr/sbin/nologin nestjs

  HEALTHCHECK --start-period=5s   →   --start-period=10s
```

`python3` kept in the builder as a safety net if a transitive dep ever needs to compile (keeps the layer slim — no full `build-essential`).

`NODE_ENV=production` baked into the runtime image so the production-env guard from PR #7 (`assertProductionEnv()`) activates without an extra Coolify env step.

## Trade-off

Final image is ~30MB larger than Alpine (~150MB vs ~120MB). Negligible vs build reliability + speed.

## Test plan

- [x] Builds locally (`docker build .`) — completes in ~90s on a clean cache
- [ ] Coolify deploy: verify build finishes in <3min and container becomes healthy
- [ ] Smoke `https://geniusidiomas.com/api/health` returns 200
- [ ] Open `/dashboard` and verify all 4 tabs load

https://claude.ai/code/session_01GJarYvsaJrh1SZPznRsiDo