### PR TITLE
feat(dashboard): currency switcher USD/CRC/BRL + fix overview crash (closes #9)

### DIFF
--- a/public/dashboard/dashboard.css
+++ b/public/dashboard/dashboard.css
@@ -343,6 +343,7 @@ body {
 
 .app-footer { text-align: center; font-size: 0.8rem; color: var(--gray-text); margin-top: 1rem; }
 .app-footer a { color: var(--navy); }
+.rate-info { display: block; margin-top: 0.35rem; font-size: 0.75rem; opacity: 0.75; }
 
 @media (max-width: 640px) {
   .app-header { padding: 0.85rem 1rem; flex-wrap: wrap; }

--- a/public/dashboard/dashboard.js
+++ b/public/dashboard/dashboard.js
@@ -3,6 +3,16 @@
 const API = '/api';
 const AUTO_REFRESH_MS = 60_000;
 
+// Currencies the dashboard knows how to display. Q10 stores all values in
+// USD on this tenant (verified live), so we treat USD as the base and
+// convert at display time only — see CurrencyService backend.
+const SUPPORTED_CURRENCIES = ['USD', 'CRC', 'BRL'];
+const CURRENCY_LOCALE = {
+  USD: { locale: 'en-US', fractionDigits: 2 },
+  CRC: { locale: 'es-CR', fractionDigits: 0 },  // colones rarely use decimals
+  BRL: { locale: 'pt-BR', fractionDigits: 2 },
+};
+
 const state = {
   user: null,
   rangeDays: 30,
@@ -12,6 +22,12 @@ const state = {
   // Cache per tab so switching back and forth doesn't re-hit /api. Invalidated
   // by refreshBtn or the 60s auto-timer.
   loaded: { overview: false, academic: false, financial: false, commercial: false },
+  // Multi-currency state — `displayCurrency` is the user's view choice
+  // (persisted in localStorage). `rates` is the USD-base table from
+  // /api/dashboard/currency-rates, lazy-loaded on first auth'd render.
+  displayCurrency: localStorage.getItem('genius:currency') || 'USD',
+  rates: { USD: 1 },  // identity until /currency-rates resolves
+  ratesFetchedAt: null,
 };
 
 // ─── Elements ───
@@ -35,10 +51,40 @@ function bindEvents() {
     if (state.activeTab === 'overview') loadOverview(false);
   });
 
+  // Currency selector — persisted, re-renders the active tab with the new
+  // labels/conversions. No backend refetch needed; we just relabel.
+  const sel = el('currencySelect');
+  if (sel) {
+    sel.value = state.displayCurrency;
+    sel.addEventListener('change', (e) => {
+      const next = e.target.value;
+      if (!SUPPORTED_CURRENCIES.includes(next)) return;
+      state.displayCurrency = next;
+      localStorage.setItem('genius:currency', next);
+      refreshActiveTab(false);
+    });
+  }
+
   // Tab navigation
   document.querySelectorAll('.tab').forEach((btn) => {
     btn.addEventListener('click', () => switchTab(btn.dataset.tab));
   });
+}
+
+// ─── Exchange rates ───
+async function loadRates() {
+  try {
+    const r = await fetch(`${API}/dashboard/currency-rates`, { credentials: 'include' });
+    if (!r.ok) return;
+    const d = await r.json();
+    if (d.rates && typeof d.rates === 'object') {
+      state.rates = d.rates;
+      state.ratesFetchedAt = d.fetchedAt;
+    }
+  } catch {
+    // Stay on identity rates — currency() falls back to a 1:1 conversion
+    // if the requested currency isn't in the rates map.
+  }
 }
 
 function switchTab(name) {
@@ -136,6 +182,9 @@ function showApp() {
   el('loginView').classList.add('hidden');
   el('appView').classList.remove('hidden');
   el('userName').textContent = state.user?.name || state.user?.email || '—';
+  // Fire rates in parallel — first paint can use identity rates if it loses
+  // the race; the next tick re-renders with the real numbers.
+  loadRates().then(() => refreshActiveTab(false));
   loadOverview(false);
   startAutoRefresh();
 }
@@ -208,10 +257,43 @@ function render(data) {
   renderFunnel(data.funnel, data.degraded);
   renderRevenueChart(data.charts.revenueByDay);
   renderStudentsChart(data.charts.newStudentsByDay);
-  renderProgramsChart(data.distributions.studentsByProgram);
-  renderOriginsChart(data.distributions.opportunitiesByOrigin);
+  // Distribution charts moved to the Académico tab — overview no longer
+  // returns `data.distributions`. Calling renderProgramsChart/Origins here
+  // would crash with "Cannot read properties of undefined".
   renderRecentStudents(data.recent.students);
   renderPendingPayments(data.recent.pendingPayments);
+  renderRateInfo();
+}
+
+function renderRateInfo() {
+  // Footer hint: "Cotación: 1 USD = R$ 5,40 · open.er-api.com" so the
+  // operator knows the conversion isn't magic — they can verify it.
+  const code = state.displayCurrency;
+  const target = el('rateInfo');
+  if (!target) return;
+  if (code === 'USD') {
+    target.textContent = '';
+    return;
+  }
+  const rate = state.rates[code];
+  if (!rate) {
+    target.textContent = '';
+    return;
+  }
+  const cfg = CURRENCY_LOCALE[code] ?? CURRENCY_LOCALE.USD;
+  const rateText = new Intl.NumberFormat(cfg.locale, {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 4,
+  }).format(rate);
+  const symbol = { USD: '$', CRC: '₡', BRL: 'R$' }[code] ?? code;
+  let when = '';
+  if (state.ratesFetchedAt && state.ratesFetchedAt !== 'fallback') {
+    const d = new Date(state.ratesFetchedAt);
+    if (!isNaN(d.getTime())) when = ` · ${d.toLocaleDateString('es')}`;
+  } else if (state.ratesFetchedAt === 'fallback') {
+    when = ' · taxa de fallback';
+  }
+  target.textContent = `Cotación: 1 USD = ${symbol} ${rateText}${when}`;
 }
 
 function renderPartialBanner(data) {
@@ -226,13 +308,24 @@ function renderPartialBanner(data) {
   banner.classList.remove('hidden');
 }
 
-function currency(n) {
-  // GTQ symbol happens to be "Q" — matches the Spanish-speaking institution context.
-  return new Intl.NumberFormat('es-GT', {
+/**
+ * Format a USD-base amount in the user's chosen display currency.
+ *
+ * Q10 stores all monetary values in USD on this tenant (verified via live
+ * probe of /pagos and /pagosPendientes). We multiply by the current rate
+ * from /api/dashboard/currency-rates and let Intl.NumberFormat handle the
+ * symbol + locale-aware grouping.
+ */
+function currency(usdAmount) {
+  const code = state.displayCurrency;
+  const rate = state.rates[code] ?? 1;  // 1:1 fallback if rate missing
+  const value = (Number(usdAmount) || 0) * rate;
+  const cfg = CURRENCY_LOCALE[code] ?? CURRENCY_LOCALE.USD;
+  return new Intl.NumberFormat(cfg.locale, {
     style: 'currency',
-    currency: 'GTQ',
-    maximumFractionDigits: 0,
-  }).format(Number(n) || 0);
+    currency: code,
+    maximumFractionDigits: cfg.fractionDigits,
+  }).format(value);
 }
 
 function renderKpis(k) {
@@ -359,46 +452,6 @@ function renderStudentsChart(series) {
       responsive: true,
       plugins: { legend: { display: false } },
       scales: { y: { beginAtZero: true, ticks: { stepSize: 1 } } },
-    },
-  });
-}
-
-function renderProgramsChart(dist) {
-  destroyChart('programs');
-  const ctx = el('programsChart').getContext('2d');
-  const labels = Object.keys(dist);
-  const values = Object.values(dist);
-  state.charts.programs = new Chart(ctx, {
-    type: 'doughnut',
-    data: {
-      labels,
-      datasets: [{
-        data: values,
-        backgroundColor: ['#000E38', '#DCAF63', '#1a2456', '#EBC584', '#606060', '#FFF8EF'],
-      }],
-    },
-    options: { responsive: true, plugins: { legend: { position: 'bottom' } } },
-  });
-}
-
-function renderOriginsChart(dist) {
-  destroyChart('origins');
-  const ctx = el('originsChart').getContext('2d');
-  state.charts.origins = new Chart(ctx, {
-    type: 'bar',
-    data: {
-      labels: Object.keys(dist),
-      datasets: [{
-        data: Object.values(dist),
-        backgroundColor: '#DCAF63',
-        borderRadius: 6,
-      }],
-    },
-    options: {
-      indexAxis: 'y',
-      responsive: true,
-      plugins: { legend: { display: false } },
-      scales: { x: { beginAtZero: true, ticks: { stepSize: 1 } } },
     },
   });
 }
@@ -696,4 +749,5 @@ function funnelStage(s) {
 function applyPartialBanner(data) {
   // Each tab can toggle the banner; when the active tab has errors, show them.
   renderPartialBanner(data);
+  renderRateInfo();
 }

--- a/public/dashboard/index.html
+++ b/public/dashboard/index.html
@@ -56,6 +56,15 @@
 
       <div class="app-header__actions">
         <div class="range-picker">
+          <label for="currencySelect">Moneda</label>
+          <select id="currencySelect" title="Moneda de visualización">
+            <option value="USD" selected>$ USD</option>
+            <option value="CRC">₡ CRC</option>
+            <option value="BRL">R$ BRL</option>
+          </select>
+        </div>
+
+        <div class="range-picker">
           <label for="rangeSelect">Rango</label>
           <select id="rangeSelect">
             <option value="7">Últimos 7 días</option>

--- a/public/dashboard/index.html
+++ b/public/dashboard/index.html
@@ -275,6 +275,7 @@
 
       <footer class="app-footer">
         © <span id="year"></span> Genius Idiomas · <a href="/">Volver al sitio</a>
+        <span id="rateInfo" class="rate-info"></span>
       </footer>
     </main>
   </section>

--- a/src/q10/dashboard.controller.ts
+++ b/src/q10/dashboard.controller.ts
@@ -2,6 +2,7 @@ import { Controller, Get, Post, Query, UseGuards } from '@nestjs/common';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { AcademicService } from './dashboard/academic.service';
 import { CommercialService } from './dashboard/commercial.service';
+import { CurrencyService } from './dashboard/currency.service';
 import { FinancialService } from './dashboard/financial.service';
 import { DashboardService } from './dashboard.service';
 import { Q10ClientService } from './q10-client.service';
@@ -14,6 +15,7 @@ export class DashboardController {
     private readonly academic: AcademicService,
     private readonly financial: FinancialService,
     private readonly commercial: CommercialService,
+    private readonly currency: CurrencyService,
     private readonly q10: Q10ClientService,
   ) {}
 
@@ -37,6 +39,16 @@ export class DashboardController {
   @Get('commercial')
   commercialView() {
     return this.commercial.commercial();
+  }
+
+  /**
+   * Exchange rates for the dashboard's currency switcher. Q10 stores all
+   * monetary values in USD on this tenant, so the FE uses these rates
+   * (USD → CRC, USD → BRL) to relabel KPIs without touching backend.
+   */
+  @Get('currency-rates')
+  rates() {
+    return this.currency.getRates();
   }
 
   @Post('refresh')

--- a/src/q10/dashboard/currency.service.ts
+++ b/src/q10/dashboard/currency.service.ts
@@ -1,0 +1,89 @@
+import { Injectable, Logger } from '@nestjs/common';
+
+export interface ExchangeRates {
+  base: string;
+  rates: Record<string, number>;
+  fetchedAt: string;
+  source: 'live' | 'cached' | 'fallback';
+}
+
+/**
+ * USD-base exchange rates fetched from open.er-api.com (free, no API key,
+ * 24h refresh). Q10 stores all monetary values in USD for this tenant
+ * (verified against /pagos and /pagosPendientes — products like "Matricula
+ * $20" make the base currency obvious; there's no per-record currency
+ * field), so the dashboard treats every Valor_pagado/Valor_saldo as USD
+ * and only converts at display time.
+ *
+ * The cache survives the JS event loop but is process-scoped — first hit
+ * after a deploy goes to the network. We fall back to a static rate table
+ * if the API is unreachable so the dashboard never breaks because of a
+ * third-party outage.
+ */
+@Injectable()
+export class CurrencyService {
+  private readonly logger = new Logger(CurrencyService.name);
+  private cache: { rates: Record<string, number>; fetchedAt: number } | null = null;
+  private readonly TTL_MS = 24 * 60 * 60 * 1000; // 24h
+
+  // Last-resort fallback if the network fetch fails on a fresh process.
+  // Updated occasionally; not meant to be precise. Better to show "stale"
+  // numbers than to crash the dashboard when open.er-api.com is down.
+  private readonly FALLBACK_RATES: Record<string, number> = {
+    USD: 1,
+    BRL: 5.4,
+    CRC: 510,
+    EUR: 0.92,
+  };
+
+  async getRates(): Promise<ExchangeRates> {
+    const now = Date.now();
+
+    if (this.cache && now - this.cache.fetchedAt < this.TTL_MS) {
+      return {
+        base: 'USD',
+        rates: this.cache.rates,
+        fetchedAt: new Date(this.cache.fetchedAt).toISOString(),
+        source: 'cached',
+      };
+    }
+
+    try {
+      const resp = await fetch('https://open.er-api.com/v6/latest/USD', {
+        signal: AbortSignal.timeout(10_000),
+      });
+      if (resp.ok) {
+        const data: any = await resp.json();
+        if (data?.result === 'success' && data?.rates && typeof data.rates === 'object') {
+          this.cache = { rates: data.rates, fetchedAt: now };
+          return {
+            base: 'USD',
+            rates: data.rates,
+            fetchedAt: new Date(now).toISOString(),
+            source: 'live',
+          };
+        }
+      }
+      this.logger.warn(`[currency] open.er-api responded ${resp.status} — using fallback`);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      this.logger.warn(`[currency] fetch failed: ${message} — using fallback`);
+    }
+
+    // Reuse stale cache if we have one — better than fallback table.
+    if (this.cache) {
+      return {
+        base: 'USD',
+        rates: this.cache.rates,
+        fetchedAt: new Date(this.cache.fetchedAt).toISOString(),
+        source: 'cached',
+      };
+    }
+    return {
+      base: 'USD',
+      rates: this.FALLBACK_RATES,
+      fetchedAt: 'fallback',
+      source: 'fallback',
+    };
+  }
+}

--- a/src/q10/q10.module.ts
+++ b/src/q10/q10.module.ts
@@ -3,6 +3,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { AuthModule } from '../auth/auth.module';
 import { AcademicService } from './dashboard/academic.service';
 import { CommercialService } from './dashboard/commercial.service';
+import { CurrencyService } from './dashboard/currency.service';
 import { FinancialService } from './dashboard/financial.service';
 import { DashboardController } from './dashboard.controller';
 import { DashboardService } from './dashboard.service';
@@ -25,6 +26,7 @@ import { TrackingService } from './tracking.service';
     AcademicService,
     FinancialService,
     CommercialService,
+    CurrencyService,
   ],
   exports: [Q10ClientService, TrackingService],
 })

--- a/test/currency.spec.ts
+++ b/test/currency.spec.ts
@@ -1,0 +1,97 @@
+import { CurrencyService } from '../src/q10/dashboard/currency.service';
+
+describe('CurrencyService', () => {
+  let svc: CurrencyService;
+
+  beforeEach(() => {
+    svc = new CurrencyService();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('returns live rates from open.er-api.com on first call', async () => {
+    const fetchSpy = jest
+      .spyOn(global, 'fetch')
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          result: 'success',
+          base_code: 'USD',
+          rates: { USD: 1, BRL: 5.4, CRC: 510 },
+        }),
+      } as Response);
+
+    const result = await svc.getRates();
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      'https://open.er-api.com/v6/latest/USD',
+      expect.any(Object),
+    );
+    expect(result.source).toBe('live');
+    expect(result.base).toBe('USD');
+    expect(result.rates.BRL).toBe(5.4);
+    expect(result.rates.CRC).toBe(510);
+  });
+
+  it('serves from cache on the second call within TTL', async () => {
+    const fetchSpy = jest
+      .spyOn(global, 'fetch')
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          result: 'success',
+          rates: { USD: 1, BRL: 5.4 },
+        }),
+      } as Response);
+
+    await svc.getRates();
+    const second = await svc.getRates();
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(second.source).toBe('cached');
+    expect(second.rates.BRL).toBe(5.4);
+  });
+
+  it('falls back to a static table when the network fails on a fresh process', async () => {
+    jest.spyOn(global, 'fetch').mockRejectedValueOnce(new Error('ECONNREFUSED'));
+
+    const result = await svc.getRates();
+
+    expect(result.source).toBe('fallback');
+    expect(result.rates.USD).toBe(1);
+    expect(result.rates.CRC).toBeGreaterThan(0);
+    expect(result.rates.BRL).toBeGreaterThan(0);
+  });
+
+  it('reuses stale cache instead of fallback when an existing cache exists', async () => {
+    // First successful fetch populates cache
+    jest.spyOn(global, 'fetch').mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ result: 'success', rates: { USD: 1, BRL: 5.0 } }),
+    } as Response);
+    await svc.getRates();
+
+    // Force the next call past TTL — manipulate the cache timestamp
+    (svc as any).cache.fetchedAt = 0;
+
+    // Network fails on the refresh attempt
+    jest.spyOn(global, 'fetch').mockRejectedValueOnce(new Error('boom'));
+
+    const result = await svc.getRates();
+    // Should serve the previous (stale) cache rather than fallback table.
+    expect(result.source).toBe('cached');
+    expect(result.rates.BRL).toBe(5.0);
+  });
+
+  it('falls back when the API returns success=false', async () => {
+    jest.spyOn(global, 'fetch').mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ result: 'error', error_type: 'unsupported-code' }),
+    } as Response);
+
+    const result = await svc.getRates();
+    expect(result.source).toBe('fallback');
+  });
+});


### PR DESCRIPTION
Two bundled changes (multi-currency + orphan fix). Closes #9.

## 1. Currency switcher in the dashboard header

Q10 stores every monetary value in USD on this tenant — verified via live probe of `/pagos` and `/pagosPendientes`:

- Product names like `"Matricula $20"` / `"Matricula $ 10"` / `"37 dolares"` make the base currency obvious
- No per-record currency field anywhere in the API responses
- Cross-referencing with student data doesn't help (CR01/CR02 = identity types, not currency)

The dashboard previously hard-coded `Q GTQ` (Guatemala quetzal), which was both wrong (Genius operates in Costa Rica + Panamá, not Guatemala) **and** unreadable to a Brazilian operator.

### What changed

- Header dropdown: `$ USD | ₡ CRC | R$ BRL`
- Choice persists in `localStorage`
- Switching is **instant** — no backend refetch, just relabel cards/charts/tables (raw values stay the same in the Q10 layer)
- Footer shows the active rate so the operator knows where the conversion came from:
  ```
  Cotación: 1 USD = R$ 5.40 · 22/04/2026
  ```

### Backend

- New `CurrencyService` that fetches USD-base rates from **open.er-api.com** (free, no API key, 24h cache)
- Stale-cache fallback when the network blips, then a static fallback table (USD=1, BRL=5.4, CRC=510, EUR=0.92) as last resort
- New `GET /api/dashboard/currency-rates` returns `{ base, rates, fetchedAt, source: 'live' | 'cached' | 'fallback' }`

### Heuristic intentionally NOT in this PR

A per-product-name heuristic (e.g., parse `"Matricula $20"` → USD vs `"Mensalidade Wendy"` → ambiguous) is **deferred** per the discussion. Chosen path: simple-first, add the heuristic if a real CRC payment starts distorting totals. The existing data is dominantly USD, so the assumption is safe today.

## 2. Fix orphan distribution-chart calls (closes #9)

Visión general was throwing:

```
⚠ Cannot read properties of undefined (reading 'studentsByProgram')
```

PR #7 split the dashboard into per-tab endpoints; `data.distributions` moved from `/api/dashboard/overview` to `/api/dashboard/academic`. The overview `render()` still called `renderProgramsChart`/`renderOriginsChart` on the now-undefined `data.distributions`. Dropped the orphan calls (distributions live on the Académico tab) and deleted the two now-unused render functions.

## Tests

- 5 new unit tests for `CurrencyService`: live fetch, cache hit, fresh-process fallback, stale-cache reuse vs fallback, API `success=false`
- Total: **75 tests / 9 specs / green**

## Test plan

- [x] `npm run build` clean
- [x] `npm test` — 75 green
- [ ] Deploy → open dashboard → verify the symbol changes when toggling USD/CRC/BRL
- [ ] Footer shows rate info ("Cotación: 1 USD = ...")
- [ ] Visión general no longer throws the studentsByProgram error
- [ ] Académico still shows program/origin distributions (those KPIs live there)

https://claude.ai/code/session_01GJarYvsaJrh1SZPznRsiDo