### PR TITLE
feat(dashboard): Turmas tab + Academic redesign + date picker + mobile responsive

### DIFF
--- a/public/dashboard/dashboard.css
+++ b/public/dashboard/dashboard.css
@@ -27,9 +27,15 @@ body {
   font-size: 15px;
   line-height: 1.5;
   -webkit-font-smoothing: antialiased;
+  -webkit-tap-highlight-color: transparent;
 }
 
 .hidden { display: none !important; }
+
+/* ─── Icon sizing ─── */
+.icon { width: 18px; height: 18px; flex-shrink: 0; stroke: currentColor; }
+.icon--xs { width: 14px; height: 14px; }
+.icon--lg { width: 28px; height: 28px; }
 
 /* ──────────────── Login ──────────────── */
 .login-view {
@@ -88,16 +94,17 @@ body {
   display: inline-flex;
   align-items: center;
   gap: 0.5rem;
-  padding: 0.65rem 1.2rem;
+  padding: 0.55rem 1rem;
   border: 1.5px solid transparent;
   border-radius: 10px;
   font-family: inherit;
   font-weight: 600;
-  font-size: 0.9rem;
+  font-size: 0.88rem;
   cursor: pointer;
   transition: transform 120ms, box-shadow 120ms, background-color 120ms;
   background: var(--white);
   color: var(--navy);
+  white-space: nowrap;
 }
 .btn-primary {
   background: var(--navy);
@@ -129,60 +136,97 @@ body {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 1.5rem;
-  padding: 1rem 2rem;
+  gap: 1rem;
+  padding: 0.85rem 1.5rem;
   background: var(--navy);
   color: var(--white);
   box-shadow: var(--shadow-md);
 }
-.app-header__brand { display: flex; align-items: center; gap: 0.9rem; }
-.app-header__logo { width: 44px; height: 44px; object-fit: contain; }
+.app-header__brand { display: flex; align-items: center; gap: 0.9rem; min-width: 0; }
+.app-header__logo { width: 40px; height: 40px; object-fit: contain; flex-shrink: 0; }
 .app-header__title {
   font-family: var(--font-display);
-  font-size: 1.15rem;
+  font-size: 1.1rem;
   letter-spacing: 0.04em;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
-.app-header__subtitle { font-size: 0.8rem; opacity: 0.7; }
+.app-header__subtitle { font-size: 0.78rem; opacity: 0.7; }
 
-.app-header__actions { display: flex; align-items: center; gap: 1rem; flex-wrap: wrap; }
+.app-header__menu {
+  display: none;
+  background: rgba(255,255,255,0.1);
+  border: 1px solid rgba(255,255,255,0.15);
+  color: var(--white);
+  border-radius: 10px;
+  width: 42px;
+  height: 42px;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+.app-header__menu:hover { background: rgba(255,255,255,0.18); }
 
-.range-picker { display: flex; align-items: center; gap: 0.5rem; font-size: 0.85rem; }
-.range-picker label { opacity: 0.8; }
-.range-picker select {
-  padding: 0.45rem 0.7rem;
+.app-header__actions { display: flex; align-items: center; gap: 0.75rem; flex-wrap: wrap; }
+
+.picker { display: flex; align-items: center; gap: 0.5rem; font-size: 0.82rem; }
+.picker label {
+  opacity: 0.85;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+.picker select,
+.picker input[type="date"] {
+  padding: 0.4rem 0.65rem;
   border-radius: 8px;
   border: 1px solid rgba(255, 255, 255, 0.2);
   background: rgba(255, 255, 255, 0.08);
   color: var(--white);
   font-family: inherit;
-  font-size: 0.85rem;
+  font-size: 0.82rem;
+  cursor: pointer;
+  color-scheme: dark;  /* native calendar popover in dark mode */
 }
-.range-picker select option { color: var(--navy); }
+.picker select option { color: var(--navy); }
+.picker__dash { opacity: 0.6; padding: 0 0.15rem; }
+.picker--custom-range { gap: 0.3rem; }
 
 .user-chip {
-  display: flex; align-items: center; gap: 0.7rem;
-  padding: 0.35rem 0.35rem 0.35rem 0.9rem;
+  display: flex; align-items: center; gap: 0.5rem;
+  padding: 0.3rem 0.3rem 0.3rem 0.8rem;
   background: rgba(255, 255, 255, 0.08);
   border-radius: 999px;
-  font-size: 0.85rem;
+  font-size: 0.82rem;
+}
+.user-chip__name {
+  max-width: 160px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 .user-chip__logout {
-  padding: 0.35rem 0.75rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.3rem 0.7rem;
   border-radius: 999px;
   border: none;
   background: var(--gold);
   color: var(--navy);
   font-family: inherit;
   font-weight: 600;
-  font-size: 0.8rem;
+  font-size: 0.78rem;
   cursor: pointer;
 }
 .user-chip__logout:hover { background: var(--gold-light); }
 
+/* ──────────────── Tabs ──────────────── */
 .tabs {
   display: flex;
   gap: 0;
-  padding: 0 2rem;
+  padding: 0 1.5rem;
   background: var(--white);
   border-bottom: 1px solid var(--border);
   overflow-x: auto;
@@ -190,13 +234,18 @@ body {
   top: 0;
   z-index: 10;
   box-shadow: 0 1px 0 var(--border);
+  scrollbar-width: none;
 }
+.tabs::-webkit-scrollbar { display: none; }
 .tab {
-  padding: 1rem 1.3rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.9rem 1.1rem;
   border: none;
   background: transparent;
   font-family: inherit;
-  font-size: 0.92rem;
+  font-size: 0.9rem;
   font-weight: 500;
   color: var(--gray-text);
   cursor: pointer;
@@ -204,6 +253,7 @@ body {
   transition: color 120ms, border-color 120ms, background-color 120ms;
   white-space: nowrap;
 }
+.tab .icon { color: currentColor; }
 .tab:hover { color: var(--navy); background: var(--cream); }
 .tab.active {
   color: var(--navy);
@@ -220,7 +270,7 @@ body {
 
 .app-main {
   flex: 1;
-  padding: 1.75rem 2rem 3rem;
+  padding: 1.5rem 1.5rem 3rem;
   max-width: 1400px;
   width: 100%;
   margin: 0 auto;
@@ -233,15 +283,17 @@ body {
 
 .partial-banner {
   display: flex;
-  flex-direction: column;
-  gap: 0.35rem;
+  gap: 0.75rem;
   padding: 0.85rem 1.1rem;
   border: 1px solid #FCD34D;
   background: #FFFBEB;
   color: #92400E;
   border-radius: var(--radius);
   font-size: 0.85rem;
+  align-items: flex-start;
 }
+.partial-banner__icon { color: #B45309; display: inline-flex; padding-top: 0.1rem; }
+.partial-banner__body { display: flex; flex-direction: column; gap: 0.2rem; }
 .partial-banner strong { color: #78350F; }
 .partial-banner code {
   background: rgba(146, 64, 14, 0.08);
@@ -255,48 +307,56 @@ body {
   background: var(--white);
   border: 1px solid var(--border);
   border-radius: var(--radius);
-  padding: 1.4rem 1.5rem;
+  padding: 1.25rem 1.4rem;
   box-shadow: var(--shadow-sm);
 }
 .card__title {
-  font-size: 0.95rem;
+  font-size: 0.92rem;
   font-weight: 700;
   color: var(--navy);
   margin-bottom: 1rem;
   letter-spacing: 0.02em;
 }
+.card--notes {
+  background: var(--cream);
+  color: var(--gray-text);
+  font-size: 0.82rem;
+  line-height: 1.6;
+}
+.card--notes strong { color: var(--navy); }
 
 .kpi-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-  gap: 1rem;
+  gap: 0.85rem;
 }
 .kpi {
   background: var(--white);
   border: 1px solid var(--border);
   border-radius: var(--radius);
-  padding: 1.1rem 1.2rem;
+  padding: 1rem 1.15rem;
   box-shadow: var(--shadow-sm);
   display: flex;
   flex-direction: column;
   gap: 0.25rem;
 }
-.kpi__label { font-size: 0.75rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.08em; color: var(--gray-text); }
-.kpi__value { font-size: 1.8rem; font-weight: 700; color: var(--navy); font-family: var(--font-display); }
-.kpi__hint { font-size: 0.75rem; color: var(--gray-text); }
+.kpi__label { font-size: 0.72rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.08em; color: var(--gray-text); }
+.kpi__value { font-size: 1.6rem; font-weight: 700; color: var(--navy); font-family: var(--font-display); line-height: 1.2; }
+.kpi__hint { font-size: 0.72rem; color: var(--gray-text); }
 .kpi--accent { border-top: 3px solid var(--gold); }
 .kpi--success .kpi__value { color: var(--success); }
 .kpi--danger .kpi__value { color: var(--danger); }
+.kpi--warning .kpi__value { color: var(--warning); }
 
 /* ──────────────── Funnel ──────────────── */
 .funnel {
   display: flex;
-  align-items: flex-end;
+  align-items: stretch;
   gap: 1rem;
   flex-wrap: wrap;
 }
 .funnel__stage {
-  flex: 1;
+  flex: 1 1 140px;
   min-width: 140px;
   background: linear-gradient(180deg, var(--cream), var(--white));
   border: 1px solid var(--border);
@@ -305,48 +365,187 @@ body {
   text-align: center;
 }
 .funnel__stage--paid { border-color: var(--gold); background: linear-gradient(180deg, #FEF3C7, var(--cream)); }
-.funnel__label { font-size: 0.75rem; font-weight: 600; text-transform: uppercase; color: var(--gray-text); letter-spacing: 0.06em; }
-.funnel__value { font-family: var(--font-display); font-size: 2rem; font-weight: 700; color: var(--navy); }
-.funnel__rate { font-size: 0.8rem; color: var(--gray-text); margin-top: 0.2rem; }
+.funnel__label { font-size: 0.72rem; font-weight: 600; text-transform: uppercase; color: var(--gray-text); letter-spacing: 0.06em; }
+.funnel__value { font-family: var(--font-display); font-size: 1.8rem; font-weight: 700; color: var(--navy); }
+.funnel__rate { font-size: 0.78rem; color: var(--gray-text); margin-top: 0.2rem; }
 
 /* ──────────────── Charts grid ──────────────── */
 .chart-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(340px, 1fr));
-  gap: 1.25rem;
+  gap: 1rem;
 }
 
 /* ──────────────── Tables ──────────────── */
-.table-wrapper { overflow-x: auto; }
-.data-table { width: 100%; border-collapse: collapse; font-size: 0.85rem; }
+.table-wrapper {
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  margin: 0 -0.3rem;  /* tiny gutter so scrollbar doesn't clip hover state */
+  padding: 0 0.3rem;
+}
+.data-table { width: 100%; border-collapse: collapse; font-size: 0.85rem; min-width: 520px; }
 .data-table th,
 .data-table td {
-  padding: 0.65rem 0.75rem;
+  padding: 0.6rem 0.7rem;
   text-align: left;
   border-bottom: 1px solid var(--border);
+  vertical-align: middle;
 }
 .data-table th {
-  font-size: 0.72rem;
+  font-size: 0.7rem;
   text-transform: uppercase;
   letter-spacing: 0.05em;
   font-weight: 600;
   color: var(--gray-text);
   background: var(--bg);
+  white-space: nowrap;
 }
 .data-table tbody tr:hover { background: var(--cream); }
 .data-table tbody tr:last-child td { border-bottom: none; }
 
-.badge { display: inline-block; padding: 0.15rem 0.55rem; border-radius: 999px; font-size: 0.7rem; font-weight: 600; background: var(--cream); color: var(--navy); }
+.badge { display: inline-block; padding: 0.15rem 0.55rem; border-radius: 999px; font-size: 0.68rem; font-weight: 600; background: var(--cream); color: var(--navy); white-space: nowrap; }
 .badge--success { background: #D1FAE5; color: var(--success); }
 .badge--danger { background: #FEE2E2; color: var(--danger); }
 .badge--warning { background: #FEF3C7; color: #92400E; }
+.badge--info { background: #DBEAFE; color: #1E40AF; }
+.badge + .badge { margin-left: 0.25rem; }
 
-.app-footer { text-align: center; font-size: 0.8rem; color: var(--gray-text); margin-top: 1rem; }
+/* ──────────────── Occupancy bar (Turmas tab) ──────────────── */
+.occupancy {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  min-width: 120px;
+}
+.occupancy__bar {
+  flex: 1;
+  height: 8px;
+  background: var(--border);
+  border-radius: 999px;
+  overflow: hidden;
+  min-width: 60px;
+}
+.occupancy__fill {
+  height: 100%;
+  background: var(--gold);
+  border-radius: 999px;
+  transition: width 200ms ease;
+}
+.occupancy__fill--warning { background: var(--warning); }
+.occupancy__fill--danger { background: var(--danger); }
+.occupancy__fill--success { background: var(--success); }
+.occupancy__text {
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: var(--navy);
+  min-width: 40px;
+  text-align: right;
+}
+
+/* ──────────────── Alert blocks (Turmas) ──────────────── */
+.alert-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1rem;
+}
+.alert-block {
+  border: 1px solid var(--border);
+  border-left: 4px solid var(--border);
+  background: var(--white);
+  border-radius: var(--radius);
+  padding: 1rem 1.1rem;
+}
+.alert-block--danger { border-left-color: var(--danger); background: #FEF2F2; }
+.alert-block--warning { border-left-color: var(--warning); background: #FFFBEB; }
+.alert-block--muted { border-left-color: var(--gray-text); background: var(--bg); }
+.alert-block__title {
+  font-size: 0.8rem;
+  font-weight: 700;
+  color: var(--navy);
+  margin-bottom: 0.6rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.alert-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  font-size: 0.82rem;
+}
+.alert-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.35rem 0;
+  border-bottom: 1px dashed rgba(0,0,0,0.06);
+}
+.alert-item:last-child { border-bottom: none; }
+.alert-item__name { font-weight: 600; color: var(--navy); }
+.alert-item__meta { font-size: 0.75rem; color: var(--gray-text); }
+
+/* ──────────────── Footer ──────────────── */
+.app-footer { text-align: center; font-size: 0.8rem; color: var(--gray-text); margin-top: 1rem; padding-bottom: 1rem; }
 .app-footer a { color: var(--navy); }
 .rate-info { display: block; margin-top: 0.35rem; font-size: 0.75rem; opacity: 0.75; }
 
-@media (max-width: 640px) {
-  .app-header { padding: 0.85rem 1rem; flex-wrap: wrap; }
+/* ──────────────── Responsive ──────────────── */
+@media (max-width: 960px) {
+  .app-header__title { font-size: 1rem; }
+  .app-header__subtitle { display: none; }
+  .kpi__value { font-size: 1.4rem; }
+  .chart-grid { grid-template-columns: 1fr; }
   .app-main { padding: 1rem; }
-  .app-header__actions { width: 100%; justify-content: space-between; }
+  .tabs { padding: 0 0.75rem; }
+  .tab { padding: 0.8rem 0.9rem; font-size: 0.85rem; }
+}
+
+@media (max-width: 720px) {
+  .app-header {
+    flex-wrap: wrap;
+    padding: 0.75rem 1rem;
+    row-gap: 0.5rem;
+  }
+  .app-header__menu { display: inline-flex; margin-left: auto; }
+  .app-header__actions {
+    display: none;
+    flex-basis: 100%;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0.75rem;
+    padding: 0.75rem 0 0.25rem;
+    border-top: 1px solid rgba(255,255,255,0.12);
+  }
+  .app-header__actions.open { display: flex; }
+  .picker { justify-content: space-between; width: 100%; }
+  .picker select,
+  .picker input[type="date"] {
+    flex: 1;
+    padding: 0.55rem 0.7rem;
+  }
+  .picker--custom-range { flex-wrap: wrap; }
+  .picker--custom-range input { min-width: 0; }
+  .user-chip { justify-content: space-between; width: 100%; border-radius: 10px; }
+  .user-chip__name { max-width: none; }
+  .btn { justify-content: center; width: 100%; }
+  .kpi-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .kpi { padding: 0.85rem 0.95rem; }
+  .kpi__value { font-size: 1.25rem; }
+  .funnel__stage { flex-basis: calc(50% - 0.5rem); min-width: 0; }
+  .funnel__value { font-size: 1.35rem; }
+  .card { padding: 1rem 1.1rem; }
+  .tab span { display: none; }  /* icon-only tabs on narrow screens */
+  .tab { padding: 0.75rem 0.8rem; }
+  .tab .icon { width: 22px; height: 22px; }
+  .alert-grid { grid-template-columns: 1fr; }
+}
+
+@media (max-width: 440px) {
+  .kpi-grid { grid-template-columns: 1fr; }
+  .funnel__stage { flex-basis: 100%; }
+  .app-header__brand { gap: 0.65rem; }
+  .app-header__logo { width: 36px; height: 36px; }
+  .app-header__title { font-size: 0.95rem; }
+  .data-table { font-size: 0.8rem; }
+  .data-table th, .data-table td { padding: 0.5rem 0.55rem; }
 }

--- a/public/dashboard/dashboard.js
+++ b/public/dashboard/dashboard.js
@@ -85,15 +85,16 @@ function bindEvents() {
       syncCustomRangeVisibility();
       onDateRangeChanged();
     });
+    const debouncedDateChanged = debounce(onDateRangeChanged, 300);
     customFrom.addEventListener('change', (e) => {
       state.customFrom = e.target.value;
       localStorage.setItem('genius:customFrom', state.customFrom);
-      if (state.datePreset === 'custom') onDateRangeChanged();
+      if (state.datePreset === 'custom') debouncedDateChanged();
     });
     customTo.addEventListener('change', (e) => {
       state.customTo = e.target.value;
       localStorage.setItem('genius:customTo', state.customTo);
-      if (state.datePreset === 'custom') onDateRangeChanged();
+      if (state.datePreset === 'custom') debouncedDateChanged();
     });
   }
 
@@ -132,6 +133,14 @@ function onDateRangeChanged() {
   if (DATE_PICKER_APPLIES_TO.has(state.activeTab)) refreshActiveTab(false);
 }
 
+function debounce(fn, ms) {
+  let timer = null;
+  return (...args) => {
+    if (timer) clearTimeout(timer);
+    timer = setTimeout(() => fn(...args), ms);
+  };
+}
+
 // Compute {from, to} in YYYY-MM-DD for the current preset.
 // Returns {} for "all" — no params → backend uses its own default window.
 function computeDateRange() {
@@ -163,7 +172,9 @@ function computeDateRange() {
       }
       return {};
     }
-    default: return {};
+    default:
+      console.warn('[dashboard] unknown datePreset:', state.datePreset);
+      return {};
   }
 }
 
@@ -173,7 +184,10 @@ function currentRangeDays() {
   if (!r.from || !r.to) return 30;
   const d1 = new Date(r.from).getTime();
   const d2 = new Date(r.to).getTime();
-  if (isNaN(d1) || isNaN(d2)) return 30;
+  if (isNaN(d1) || isNaN(d2)) {
+    console.warn('[dashboard] currentRangeDays: unparsable range', r);
+    return 30;
+  }
   return Math.max(1, Math.round((d2 - d1) / 86400000) + 1);
 }
 
@@ -622,6 +636,16 @@ function escapeHtml(v) {
   }[c]));
 }
 
+// Reorder a CEFR distribution respecting `levelsOrder` (A1 → C2). Any key
+// not in the canonical order gets appended at the end so nothing disappears
+// if Q10 introduces a new level we haven't seen.
+function orderedCefr(raw, order) {
+  const out = {};
+  for (const lv of order) if (raw[lv] != null) out[lv] = raw[lv];
+  for (const k of Object.keys(raw)) if (!(k in out)) out[k] = raw[k];
+  return out;
+}
+
 // Render a simple `key: count` distribution as a horizontal bar chart.
 function renderDistributionChart(canvasId, dist, colour = '#000E38') {
   destroyChart(canvasId);
@@ -710,15 +734,6 @@ async function loadAcademic(force) {
     { label: 'Churn', value: r.churned, sub: r.churnRate != null ? `${r.churnRate}% salieron` : '—' },
     { label: 'Nuevos', value: r.newcomers, sub: 'entraron ahora' },
   ].map(funnelStage).join('');
-
-  // Helper: reorder a distribution object to respect a predefined key order
-  // (keys outside the order list are appended in their original order).
-  const orderedCefr = (raw, order) => {
-    const out = {};
-    for (const lv of order) if (raw[lv] != null) out[lv] = raw[lv];
-    for (const k of Object.keys(raw)) if (!(k in out)) out[k] = raw[k];
-    return out;
-  };
 
   const dist = data.distributions || {};
   const prog = data.progression || {};

--- a/public/dashboard/dashboard.js
+++ b/public/dashboard/dashboard.js
@@ -13,21 +13,29 @@ const CURRENCY_LOCALE = {
   BRL: { locale: 'pt-BR', fractionDigits: 2 },
 };
 
+// Date picker state — `preset` controls which KPIs we send from/to for.
+// Only Overview and Financial are date-sensitive; Academic + Turmas +
+// Commercial are period-based on the server and ignore from/to.
+const DATE_PICKER_APPLIES_TO = new Set(['overview', 'financial']);
 const state = {
   user: null,
-  rangeDays: 30,
   charts: {},
   timer: null,
   activeTab: 'overview',
   // Cache per tab so switching back and forth doesn't re-hit /api. Invalidated
   // by refreshBtn or the 60s auto-timer.
-  loaded: { overview: false, academic: false, financial: false, commercial: false },
+  loaded: { overview: false, academic: false, turmas: false, financial: false, commercial: false },
   // Multi-currency state — `displayCurrency` is the user's view choice
   // (persisted in localStorage). `rates` is the USD-base table from
   // /api/dashboard/currency-rates, lazy-loaded on first auth'd render.
   displayCurrency: localStorage.getItem('genius:currency') || 'USD',
   rates: { USD: 1 },  // identity until /currency-rates resolves
   ratesFetchedAt: null,
+  // Date picker — persisted in localStorage so the operator's last choice
+  // survives reloads. `custom` adds from/to inputs.
+  datePreset: localStorage.getItem('genius:datePreset') || 'month',
+  customFrom: localStorage.getItem('genius:customFrom') || '',
+  customTo: localStorage.getItem('genius:customTo') || '',
 };
 
 // ─── Elements ───
@@ -44,12 +52,6 @@ function bindEvents() {
   el('loginForm').addEventListener('submit', onLogin);
   el('logoutBtn').addEventListener('click', onLogout);
   el('refreshBtn').addEventListener('click', () => refreshActiveTab(true));
-  el('rangeSelect').addEventListener('change', (e) => {
-    state.rangeDays = Number(e.target.value);
-    // Range only affects Overview; other tabs ignore it.
-    state.loaded.overview = false;
-    if (state.activeTab === 'overview') loadOverview(false);
-  });
 
   // Currency selector — persisted, re-renders the active tab with the new
   // labels/conversions. No backend refetch needed; we just relabel.
@@ -65,10 +67,114 @@ function bindEvents() {
     });
   }
 
+  // Date picker — presets (Hoy / Últimos 7 / Este mes / etc.) + custom range.
+  // Only invalidates the date-sensitive tabs (overview/financial); the others
+  // run off period data and ignore from/to.
+  const preset = el('datePreset');
+  const customWrap = el('customRangeWrap');
+  const customFrom = el('customFrom');
+  const customTo = el('customTo');
+  if (preset) {
+    preset.value = state.datePreset;
+    syncCustomRangeVisibility();
+    if (state.customFrom) customFrom.value = state.customFrom;
+    if (state.customTo) customTo.value = state.customTo;
+    preset.addEventListener('change', (e) => {
+      state.datePreset = e.target.value;
+      localStorage.setItem('genius:datePreset', state.datePreset);
+      syncCustomRangeVisibility();
+      onDateRangeChanged();
+    });
+    customFrom.addEventListener('change', (e) => {
+      state.customFrom = e.target.value;
+      localStorage.setItem('genius:customFrom', state.customFrom);
+      if (state.datePreset === 'custom') onDateRangeChanged();
+    });
+    customTo.addEventListener('change', (e) => {
+      state.customTo = e.target.value;
+      localStorage.setItem('genius:customTo', state.customTo);
+      if (state.datePreset === 'custom') onDateRangeChanged();
+    });
+  }
+
+  // Mobile drawer — below 720px the header actions collapse behind a hamburger.
+  const menuBtn = el('menuBtn');
+  const actions = el('headerActions');
+  if (menuBtn && actions) {
+    menuBtn.addEventListener('click', () => {
+      const open = actions.classList.toggle('open');
+      menuBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+    });
+    // Close the drawer when tapping outside it (convenience on mobile).
+    document.addEventListener('click', (e) => {
+      if (!actions.classList.contains('open')) return;
+      if (actions.contains(e.target) || menuBtn.contains(e.target)) return;
+      actions.classList.remove('open');
+      menuBtn.setAttribute('aria-expanded', 'false');
+    });
+  }
+
   // Tab navigation
   document.querySelectorAll('.tab').forEach((btn) => {
     btn.addEventListener('click', () => switchTab(btn.dataset.tab));
   });
+}
+
+function syncCustomRangeVisibility() {
+  const wrap = el('customRangeWrap');
+  if (!wrap) return;
+  wrap.classList.toggle('hidden', state.datePreset !== 'custom');
+}
+
+function onDateRangeChanged() {
+  // Invalidate the cache of every date-sensitive tab so a re-open re-fetches.
+  for (const tab of DATE_PICKER_APPLIES_TO) state.loaded[tab] = false;
+  if (DATE_PICKER_APPLIES_TO.has(state.activeTab)) refreshActiveTab(false);
+}
+
+// Compute {from, to} in YYYY-MM-DD for the current preset.
+// Returns {} for "all" — no params → backend uses its own default window.
+function computeDateRange() {
+  const today = new Date();
+  const iso = (d) => {
+    const y = d.getFullYear();
+    const m = String(d.getMonth() + 1).padStart(2, '0');
+    const day = String(d.getDate()).padStart(2, '0');
+    return `${y}-${m}-${day}`;
+  };
+  const daysAgo = (n) => {
+    const d = new Date(today);
+    d.setDate(d.getDate() - n);
+    return d;
+  };
+  switch (state.datePreset) {
+    case 'today':  return { from: iso(today), to: iso(today) };
+    case 'last7':  return { from: iso(daysAgo(6)), to: iso(today) };
+    case 'month': {
+      const first = new Date(today.getFullYear(), today.getMonth(), 1);
+      return { from: iso(first), to: iso(today) };
+    }
+    case 'last30': return { from: iso(daysAgo(29)), to: iso(today) };
+    case 'last90': return { from: iso(daysAgo(89)), to: iso(today) };
+    case 'year':   return { from: iso(daysAgo(364)), to: iso(today) };
+    case 'custom': {
+      if (state.customFrom && state.customTo) {
+        return { from: state.customFrom, to: state.customTo };
+      }
+      return {};
+    }
+    default: return {};
+  }
+}
+
+// Approx days span of the current range — used for KPI hint text.
+function currentRangeDays() {
+  const r = computeDateRange();
+  if (!r.from || !r.to) return 30;
+  const d1 = new Date(r.from).getTime();
+  const d2 = new Date(r.to).getTime();
+  if (isNaN(d1) || isNaN(d2)) return 30;
+  return Math.max(1, Math.round((d2 - d1) / 86400000) + 1);
 }
 
 // ─── Exchange rates ───
@@ -97,8 +203,6 @@ function switchTab(name) {
   document.querySelectorAll('.tab-panel').forEach((p) => {
     p.classList.toggle('hidden', p.id !== `tab-${name}`);
   });
-  // Range picker is only meaningful on the Overview tab.
-  el('rangeSelect').style.display = name === 'overview' ? '' : 'none';
   // Load lazily the first time the tab is opened.
   if (!state.loaded[name]) loadTab(name, false);
 }
@@ -110,6 +214,7 @@ function refreshActiveTab(force) {
 function loadTab(name, force) {
   if (name === 'overview') return loadOverview(force);
   if (name === 'academic') return loadAcademic(force);
+  if (name === 'turmas') return loadTurmas(force);
   if (name === 'financial') return loadFinancial(force);
   if (name === 'commercial') return loadCommercial(force);
 }
@@ -215,7 +320,7 @@ async function fetchTab(path, force) {
     setFreshness(`Actualizado a las ${new Date().toLocaleTimeString('es')}`);
     return data;
   } catch (err) {
-    setFreshness(`⚠ ${err.message || 'Error inesperado'}`);
+    setFreshness(`Error: ${err.message || 'Error inesperado'}`);
     return null;
   }
 }
@@ -227,8 +332,15 @@ async function loadOverview(force) {
     if (force) {
       await fetch(`${API}/dashboard/refresh`, { method: 'POST', credentials: 'include' });
     }
+    const r = computeDateRange();
+    const params = new URLSearchParams();
+    params.set('range', String(currentRangeDays()));
+    if (r.from && r.to) {
+      params.set('from', r.from);
+      params.set('to', r.to);
+    }
     const resp = await fetch(
-      `${API}/dashboard/overview?range=${state.rangeDays}`,
+      `${API}/dashboard/overview?${params.toString()}`,
       { credentials: 'include' },
     );
     if (resp.status === 401) {
@@ -242,7 +354,7 @@ async function loadOverview(force) {
     state.loaded.overview = true;
     setFreshness(`Actualizado a las ${new Date().toLocaleTimeString('es')}`);
   } catch (err) {
-    setFreshness(`⚠ ${err.message || 'Error inesperado'}`);
+    setFreshness(`Error: ${err.message || 'Error inesperado'}`);
   }
 }
 
@@ -333,7 +445,7 @@ function renderKpis(k) {
   // (backend uses null to signal "this KPI isn't reliable on this plan").
   const cards = [];
   cards.push({ label: 'Estudiantes activos', value: k.activeStudents, hint: `${k.totalStudents} matriculados`, accent: true });
-  cards.push({ label: 'Nuevos en el rango', value: k.newStudentsInRange, hint: `${state.rangeDays} días` });
+  cards.push({ label: 'Nuevos en el rango', value: k.newStudentsInRange, hint: `${currentRangeDays()} días` });
   cards.push({ label: 'Nuevos este período', value: k.newEnrollmentsThisPeriod, hint: 'vs. renovados' });
   cards.push({ label: 'Contactos en CRM', value: k.totalContacts, hint: 'leads registrados' });
   cards.push({ label: 'Oportunidades', value: k.oppsTotal, hint: 'total en el CRM' });
@@ -345,7 +457,7 @@ function renderKpis(k) {
       variant: k.conversionRate >= 30 ? 'success' : '',
     });
   }
-  cards.push({ label: 'Ingresos del período', value: currency(k.revenueInRange), hint: `${state.rangeDays} días`, variant: 'success' });
+  cards.push({ label: 'Ingresos del período', value: currency(k.revenueInRange), hint: `${currentRangeDays()} días`, variant: 'success' });
   cards.push({ label: 'Deuda pendiente', value: currency(k.outstandingDebt), hint: `${k.ordersPending} cuotas abiertas`, variant: k.outstandingDebt > 0 ? 'danger' : '' });
   cards.push({ label: 'Alumnos con pago', value: k.studentsWithPaymentThisPeriod, hint: `de ${k.totalStudents} matrículas` });
 
@@ -599,13 +711,56 @@ async function loadAcademic(force) {
     { label: 'Nuevos', value: r.newcomers, sub: 'entraron ahora' },
   ].map(funnelStage).join('');
 
-  // Charts
-  renderDistributionChart('jornadaChart', data.distributions.byJornada, '#DCAF63');
-  renderDistributionChart('nivelChart', data.distributions.byNivel, '#000E38');
-  renderDonut('genderChart', data.distributions.byGender);
-  renderDistributionChart('ageChart', data.distributions.byAge, '#1a2456');
+  // Helper: reorder a distribution object to respect a predefined key order
+  // (keys outside the order list are appended in their original order).
+  const orderedCefr = (raw, order) => {
+    const out = {};
+    for (const lv of order) if (raw[lv] != null) out[lv] = raw[lv];
+    for (const k of Object.keys(raw)) if (!(k in out)) out[k] = raw[k];
+    return out;
+  };
 
-  // Teachers table
+  const dist = data.distributions || {};
+  const prog = data.progression || {};
+  const levelsOrder = prog.levelsOrder || [];
+
+  // Distribution charts
+  renderDonut('modalityChart', dist.byModality || {});
+  renderDistributionChart('cityChart', dist.byCity || {}, '#DCAF63');
+  renderDistributionChart(
+    'cefrRegularChart',
+    orderedCefr(prog.distributionRegular || {}, levelsOrder),
+    '#DCAF63',
+  );
+  renderDistributionChart(
+    'cefrIntensivoChart',
+    orderedCefr(prog.distributionIntensivo || {}, levelsOrder),
+    '#000E38',
+  );
+  renderDistributionChart('jornadaChart', dist.byJornada || {}, '#DCAF63');
+  renderDonut('genderChart', dist.byGender || {});
+  renderDistributionChart('ageChart', dist.byAge || {}, '#1a2456');
+
+  // Risk flags table
+  const riskBody = document.querySelector('#riskTable tbody');
+  const riskFlags = data.riskFlags || [];
+  if (!riskFlags.length) {
+    riskBody.innerHTML = '<tr><td colspan="8" style="text-align:center;color:var(--gray-text)">Sin alumnos en riesgo</td></tr>';
+  } else {
+    riskBody.innerHTML = riskFlags.map((rf) => `
+      <tr>
+        <td>${escapeHtml(rf.nombre || '—')}</td>
+        <td>${escapeHtml(rf.nivel || '—')}</td>
+        <td>${escapeHtml(rf.modality || '—')}</td>
+        <td>${escapeHtml(rf.curso || '—')}</td>
+        <td>${escapeHtml(String(rf.mesesMatriculado ?? '—'))}</td>
+        <td>${escapeHtml(rf.inasistencia != null ? `${rf.inasistencia}%` : '—')}</td>
+        <td>${escapeHtml(rf.promedio != null ? String(rf.promedio) : '—')}</td>
+        <td>${escapeHtml(Array.isArray(rf.flags) ? rf.flags.join(', ') : '—')}</td>
+      </tr>`).join('');
+  }
+
+  // Teachers table (unchanged — 4 cols)
   const tbody = document.querySelector('#teachersTable tbody');
   if (!data.teachers.length) {
     tbody.innerHTML = '<tr><td colspan="4" style="text-align:center;color:var(--gray-text)">Sin docentes</td></tr>';
@@ -624,7 +779,14 @@ async function loadAcademic(force) {
 
 // ═════════════════ FINANCIAL TAB ═════════════════
 async function loadFinancial(force) {
-  const data = await fetchTab(`${API}/dashboard/financial?months=12`, force);
+  const r = computeDateRange();
+  const params = new URLSearchParams();
+  params.set('months', '12');
+  if (r.from && r.to) {
+    params.set('from', r.from);
+    params.set('to', r.to);
+  }
+  const data = await fetchTab(`${API}/dashboard/financial?${params.toString()}`, force);
   if (!data) return;
   state.loaded.financial = true;
 
@@ -640,6 +802,7 @@ async function loadFinancial(force) {
 
   renderMonthlyLine('mrrChart', data.charts.revenueByMonth, '#DCAF63', true);
   renderDistributionChart('revenueByProgramChart', data.charts.revenueByConcept, '#DCAF63');
+  renderDistributionChart('revenueByModalityChart', data.charts.revenueByModality, '#1a2456');
 
   // Top debtors table
   const debt = document.querySelector('#debtorsTable tbody');
@@ -672,6 +835,121 @@ async function loadFinancial(force) {
   }
 
   applyPartialBanner(data);
+}
+
+// ═════════════════ TURMAS TAB ═════════════════
+async function loadTurmas(force) {
+  const data = await fetchTab(`${API}/dashboard/turmas`, force);
+  if (!data) return;
+
+  const s = data.summary || {};
+  const dist = data.distributions || {};
+  const alerts = data.alerts || {};
+  const notes = data.notes || {};
+
+  // Occupation variant: green ≥80, warning ≥50, danger below.
+  const ocupVariant =
+    s.ocupacionMedia == null ? ''
+      : s.ocupacionMedia >= 80 ? 'success'
+      : s.ocupacionMedia >= 50 ? 'warning'
+      : 'danger';
+
+  el('turmasKpis').innerHTML = [
+    { label: 'Cursos activos', value: s.totalCursos ?? '—', hint: 'en el período', accent: true },
+    { label: 'Ocupación media', value: s.ocupacionMedia != null ? `${s.ocupacionMedia}%` : '—', hint: 'matrículas / cupos', variant: ocupVariant },
+    { label: 'Estudiantes matriculados', value: s.totalMatriculados ?? '—', hint: `de ${s.totalCupo ?? 0} cupos` },
+    { label: 'Llenos (≥90%)', value: s.overbookedCount ?? 0, hint: 'cerca del tope', variant: (s.overbookedCount || 0) > 0 ? 'danger' : '' },
+    { label: 'Bajo 5 alumnos', value: s.underbookedCount ?? 0, hint: 'cursos en riesgo', variant: (s.underbookedCount || 0) > 0 ? 'warning' : '' },
+    { label: 'Sin estudiantes', value: s.emptyCount ?? 0, hint: 'cursos vacíos', variant: (s.emptyCount || 0) > 0 ? 'danger' : '' },
+    { label: 'Docentes activos', value: s.docentesActivos ?? '—', hint: 'con carga' },
+  ].map(kpiCard).join('');
+
+  // Distribution charts
+  renderDonut('turmasModalityChart', dist.byModality || {});
+  renderDistributionChart('turmasCityChart', dist.byCity || {}, '#DCAF63');
+
+  // Alert blocks
+  const renderAlertList = (id, items) => {
+    const target = el(id);
+    if (!target) return;
+    if (!items || !items.length) {
+      target.innerHTML = '<div class="alert-item alert-item--empty">Ninguno</div>';
+      return;
+    }
+    target.innerHTML = items.map((it) => {
+      const mat = it.matriculados ?? 0;
+      const cup = it.cupo ?? 0;
+      const oc = it.ocupacion ?? null;
+      return `<div class="alert-item"><strong>${escapeHtml(it.Nombre || '—')}</strong><span>${escapeHtml(String(mat))}/${escapeHtml(String(cup))} · ${oc != null ? escapeHtml(String(oc)) : '—'}%</span></div>`;
+    }).join('');
+  };
+  renderAlertList('overbookedList', alerts.overbooked);
+  renderAlertList('underbookedList', alerts.underbooked);
+  renderAlertList('emptyList', alerts.empty);
+
+  // Courses table
+  const coursesBody = document.querySelector('#coursesTable tbody');
+  const courses = data.courses || [];
+  if (!courses.length) {
+    coursesBody.innerHTML = '<tr><td colspan="8" style="text-align:center;color:var(--gray-text)">Sin cursos</td></tr>';
+  } else {
+    coursesBody.innerHTML = courses.map((c) => {
+      const pct = c.ocupacion;
+      let occupancyCell;
+      if (pct == null) {
+        occupancyCell = '—';
+      } else {
+        const band = pct >= 90 ? 'danger'
+          : pct >= 50 ? 'success'
+          : pct > 0 ? 'warning'
+          : 'muted';
+        occupancyCell = `<div class="occupancy">
+          <div class="occupancy__bar"><div class="occupancy__fill occupancy__fill--${band}" style="width:${pct}%"></div></div>
+          <span>${pct}%</span>
+        </div>`;
+      }
+      return `<tr>
+        <td>${escapeHtml(c.Nombre || '—')}</td>
+        <td>${escapeHtml(c.Nivel || '—')}</td>
+        <td>${escapeHtml(c.modality || '—')}</td>
+        <td>${escapeHtml(c.Sede || '—')}</td>
+        <td>${escapeHtml(c.Docente || '—')}</td>
+        <td>${escapeHtml(String(c.matriculados ?? 0))}</td>
+        <td>${escapeHtml(String(c.cupo ?? 0))}</td>
+        <td>${occupancyCell}</td>
+      </tr>`;
+    }).join('');
+  }
+
+  // Teachers table
+  const teachersBody = document.querySelector('#turmasTeachersTable tbody');
+  const teachers = data.teachers || [];
+  if (!teachers.length) {
+    teachersBody.innerHTML = '<tr><td colspan="4" style="text-align:center;color:var(--gray-text)">Sin docentes</td></tr>';
+  } else {
+    teachersBody.innerHTML = teachers.map((t) => `
+      <tr>
+        <td>${escapeHtml(t.nombre || '—')}</td>
+        <td>${escapeHtml(String(t.cursos ?? 0))}</td>
+        <td>${escapeHtml(String(t.estudiantes ?? 0))}</td>
+        <td>${escapeHtml(String(t.cupoTotal ?? 0))}</td>
+      </tr>`).join('');
+  }
+
+  // Notes — render non-empty string values as bullet paragraphs.
+  const notesTarget = el('turmasNotes');
+  if (notesTarget) {
+    const values = Object.values(notes).filter((v) => typeof v === 'string' && v.trim() !== '');
+    if (!values.length) {
+      notesTarget.innerHTML = '';
+    } else {
+      notesTarget.innerHTML = values.map((v) => `
+        <p><svg class="icon icon--xs"><use href="#icon-alert"/></svg> ${escapeHtml(v)}</p>`).join('');
+    }
+  }
+
+  applyPartialBanner(data);
+  state.loaded.turmas = true;
 }
 
 // ═════════════════ COMMERCIAL TAB ═════════════════

--- a/public/dashboard/dashboard.js
+++ b/public/dashboard/dashboard.js
@@ -636,15 +636,8 @@ function escapeHtml(v) {
   }[c]));
 }
 
-// Reorder a CEFR distribution respecting `levelsOrder` (A1 → C2). Any key
-// not in the canonical order gets appended at the end so nothing disappears
-// if Q10 introduces a new level we haven't seen.
-function orderedCefr(raw, order) {
-  const out = {};
-  for (const lv of order) if (raw[lv] != null) out[lv] = raw[lv];
-  for (const k of Object.keys(raw)) if (!(k in out)) out[k] = raw[k];
-  return out;
-}
+// `orderedCefr` now lives in /dashboard/helpers.js — loaded before this
+// script so it's available on the global scope.
 
 // Render a simple `key: count` distribution as a horizontal bar chart.
 function renderDistributionChart(canvasId, dist, colour = '#000E38') {

--- a/public/dashboard/helpers.js
+++ b/public/dashboard/helpers.js
@@ -1,0 +1,28 @@
+/* Genius Dashboard — pure frontend helpers
+ *
+ * Browser-side counterpart to src/q10/dashboard/helpers.ts. The backend file
+ * is TypeScript compiled for Node and can't be imported by the browser, so
+ * pure presentational helpers that deserve to be reused across scripts live
+ * here. Kept framework-free (no Chart.js / no DOM), just functions that
+ * transform data for display.
+ *
+ * Loaded via <script src="/dashboard/helpers.js"></script> BEFORE
+ * dashboard.js, so these are available on the global scope for the main
+ * module to consume.
+ */
+
+/**
+ * Reorder a CEFR distribution respecting `levelsOrder` (A1 → C2).
+ * Any key not in the canonical order gets appended at the end so nothing
+ * disappears if Q10 introduces a new level we haven't seen before.
+ *
+ * @param {Record<string, number>} raw - e.g. { B1: 10, A1: 5, A2: 8 }
+ * @param {string[]} order - canonical CEFR order from the backend
+ * @returns {Record<string, number>}
+ */
+function orderedCefr(raw, order) {
+  const out = {};
+  for (const lv of order) if (raw[lv] != null) out[lv] = raw[lv];
+  for (const k of Object.keys(raw)) if (!(k in out)) out[k] = raw[k];
+  return out;
+}

--- a/public/dashboard/index.html
+++ b/public/dashboard/index.html
@@ -2,9 +2,10 @@
 <html lang="es">
 <head>
   <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <title>Dashboard — Genius Idiomas</title>
   <meta name="robots" content="noindex, nofollow">
+  <meta name="theme-color" content="#000E38">
 
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -16,6 +17,58 @@
   <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.4/dist/chart.umd.min.js"></script>
 </head>
 <body>
+
+  <!-- Inline SVG sprite — single source of truth for all icons across the
+       dashboard. Referenced via <svg><use href="#icon-foo"/></svg>. Replaces
+       the previous emoji set (tabs, banner, etc.) for a cleaner, more
+       professional look that also renders consistently on Windows/Android. -->
+  <svg xmlns="http://www.w3.org/2000/svg" style="display:none" aria-hidden="true">
+    <defs>
+      <symbol id="icon-overview" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <rect x="3" y="3" width="7" height="9"/><rect x="14" y="3" width="7" height="5"/>
+        <rect x="14" y="12" width="7" height="9"/><rect x="3" y="16" width="7" height="5"/>
+      </symbol>
+      <symbol id="icon-academic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M22 10v6M2 10l10-5 10 5-10 5z"/><path d="M6 12v5c3 3 9 3 12 0v-5"/>
+      </symbol>
+      <symbol id="icon-financial" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <line x1="12" y1="1" x2="12" y2="23"/>
+        <path d="M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6"/>
+      </symbol>
+      <symbol id="icon-commercial" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <circle cx="12" cy="12" r="10"/><circle cx="12" cy="12" r="6"/><circle cx="12" cy="12" r="2"/>
+      </symbol>
+      <symbol id="icon-turmas" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/>
+        <circle cx="9" cy="7" r="4"/>
+        <path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/>
+      </symbol>
+      <symbol id="icon-refresh" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <polyline points="23 4 23 10 17 10"/><polyline points="1 20 1 14 7 14"/>
+        <path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15"/>
+      </symbol>
+      <symbol id="icon-alert" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/>
+        <line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/>
+      </symbol>
+      <symbol id="icon-calendar" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <rect x="3" y="4" width="18" height="18" rx="2" ry="2"/>
+        <line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/>
+        <line x1="3" y1="10" x2="21" y2="10"/>
+      </symbol>
+      <symbol id="icon-logout" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"/>
+        <polyline points="16 17 21 12 16 7"/><line x1="21" y1="12" x2="9" y2="12"/>
+      </symbol>
+      <symbol id="icon-menu" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/>
+        <line x1="3" y1="18" x2="21" y2="18"/>
+      </symbol>
+      <symbol id="icon-close" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/>
+      </symbol>
+    </defs>
+  </svg>
 
   <!-- Login view -->
   <section id="loginView" class="login-view">
@@ -54,8 +107,13 @@
         </div>
       </div>
 
-      <div class="app-header__actions">
-        <div class="range-picker">
+      <!-- Mobile trigger — expands the actions drawer below 720px. -->
+      <button class="app-header__menu" id="menuBtn" type="button" aria-label="Mostrar acciones" aria-expanded="false" aria-controls="headerActions">
+        <svg class="icon"><use href="#icon-menu"/></svg>
+      </button>
+
+      <div class="app-header__actions" id="headerActions">
+        <div class="picker">
           <label for="currencySelect">Moneda</label>
           <select id="currencySelect" title="Moneda de visualización">
             <option value="USD" selected>$ USD</option>
@@ -64,41 +122,78 @@
           </select>
         </div>
 
-        <div class="range-picker">
-          <label for="rangeSelect">Rango</label>
-          <select id="rangeSelect">
-            <option value="7">Últimos 7 días</option>
-            <option value="30" selected>Últimos 30 días</option>
-            <option value="90">Últimos 90 días</option>
-            <option value="365">Último año</option>
+        <!-- New date picker: presets + optional custom range. Applies to the
+             Overview + Financial tabs; Academic/Commercial are period-based
+             and ignore it (see dashboard.js#datePickerAppliesTo). -->
+        <div class="picker picker--date">
+          <label for="datePreset">
+            <svg class="icon icon--xs" aria-hidden="true"><use href="#icon-calendar"/></svg>
+            Período
+          </label>
+          <select id="datePreset">
+            <option value="today">Hoy</option>
+            <option value="last7">Últimos 7 días</option>
+            <option value="month" selected>Este mes</option>
+            <option value="last30">Últimos 30 días</option>
+            <option value="last90">Últimos 90 días</option>
+            <option value="year">Último año</option>
+            <option value="custom">Fecha seleccionada…</option>
           </select>
         </div>
 
+        <div class="picker picker--custom-range hidden" id="customRangeWrap">
+          <input type="date" id="customFrom" aria-label="Desde">
+          <span class="picker__dash">—</span>
+          <input type="date" id="customTo" aria-label="Hasta">
+        </div>
+
         <button class="btn btn-secondary" id="refreshBtn" title="Forzar actualización">
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="23 4 23 10 17 10"/><polyline points="1 20 1 14 7 14"/><path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15"/></svg>
-          Actualizar
+          <svg class="icon" aria-hidden="true"><use href="#icon-refresh"/></svg>
+          <span class="btn__label">Actualizar</span>
         </button>
 
         <div class="user-chip" id="userChip">
           <span class="user-chip__name" id="userName">—</span>
-          <button class="user-chip__logout" id="logoutBtn" title="Cerrar sesión">Salir</button>
+          <button class="user-chip__logout" id="logoutBtn" title="Cerrar sesión" aria-label="Salir">
+            <svg class="icon icon--xs" aria-hidden="true"><use href="#icon-logout"/></svg>
+            <span class="btn__label">Salir</span>
+          </button>
         </div>
       </div>
     </header>
 
     <nav class="tabs" id="tabs" role="tablist">
-      <button class="tab active" data-tab="overview" role="tab" aria-selected="true">📊 Visión general</button>
-      <button class="tab" data-tab="academic" role="tab">🎓 Académico</button>
-      <button class="tab" data-tab="financial" role="tab">💰 Financiero</button>
-      <button class="tab" data-tab="commercial" role="tab">🎯 Comercial / CRM</button>
+      <button class="tab active" data-tab="overview" role="tab" aria-selected="true">
+        <svg class="icon" aria-hidden="true"><use href="#icon-overview"/></svg>
+        <span>Visión general</span>
+      </button>
+      <button class="tab" data-tab="academic" role="tab">
+        <svg class="icon" aria-hidden="true"><use href="#icon-academic"/></svg>
+        <span>Académico</span>
+      </button>
+      <button class="tab" data-tab="turmas" role="tab">
+        <svg class="icon" aria-hidden="true"><use href="#icon-turmas"/></svg>
+        <span>Turmas</span>
+      </button>
+      <button class="tab" data-tab="financial" role="tab">
+        <svg class="icon" aria-hidden="true"><use href="#icon-financial"/></svg>
+        <span>Financiero</span>
+      </button>
+      <button class="tab" data-tab="commercial" role="tab">
+        <svg class="icon" aria-hidden="true"><use href="#icon-commercial"/></svg>
+        <span>Comercial / CRM</span>
+      </button>
     </nav>
 
     <main class="app-main">
       <div class="freshness" id="freshness">Cargando…</div>
 
       <div class="partial-banner hidden" id="partialBanner" role="alert">
-        <strong>⚠ Datos parciales</strong>
-        <span id="partialBannerDetail"></span>
+        <span class="partial-banner__icon"><svg class="icon" aria-hidden="true"><use href="#icon-alert"/></svg></span>
+        <div class="partial-banner__body">
+          <strong>Datos parciales</strong>
+          <span id="partialBannerDetail"></span>
+        </div>
       </div>
 
       <!-- ───────────── TAB: Overview ───────────── -->
@@ -154,16 +249,31 @@
 
         <section class="chart-grid">
           <div class="card">
-            <h2 class="card__title">Por jornada</h2>
-            <canvas id="jornadaChart" height="140"></canvas>
+            <h2 class="card__title">Por modalidad</h2>
+            <canvas id="modalityChart" height="140"></canvas>
           </div>
           <div class="card">
-            <h2 class="card__title">Por nivel CEFR</h2>
-            <canvas id="nivelChart" height="140"></canvas>
+            <h2 class="card__title">Por ciudad / clase</h2>
+            <canvas id="cityChart" height="140"></canvas>
           </div>
         </section>
 
         <section class="chart-grid">
+          <div class="card">
+            <h2 class="card__title">Nivel CEFR — Regular</h2>
+            <canvas id="cefrRegularChart" height="140"></canvas>
+          </div>
+          <div class="card">
+            <h2 class="card__title">Nivel CEFR — Semi Intensivo</h2>
+            <canvas id="cefrIntensivoChart" height="140"></canvas>
+          </div>
+        </section>
+
+        <section class="chart-grid">
+          <div class="card">
+            <h2 class="card__title">Por jornada</h2>
+            <canvas id="jornadaChart" height="140"></canvas>
+          </div>
           <div class="card">
             <h2 class="card__title">Por género</h2>
             <canvas id="genderChart" height="140"></canvas>
@@ -171,6 +281,19 @@
           <div class="card">
             <h2 class="card__title">Por rango de edad</h2>
             <canvas id="ageChart" height="140"></canvas>
+          </div>
+        </section>
+
+        <section class="card">
+          <h2 class="card__title">Alumnos en riesgo</h2>
+          <div class="table-wrapper">
+            <table class="data-table" id="riskTable">
+              <thead><tr>
+                <th>Nombre</th><th>Nivel</th><th>Modalidad</th><th>Curso</th>
+                <th>Meses</th><th>% Faltas</th><th>Nota</th><th>Alertas</th>
+              </tr></thead>
+              <tbody></tbody>
+            </table>
           </div>
         </section>
 
@@ -185,20 +308,88 @@
         </section>
       </div>
 
+      <!-- ───────────── TAB: Turmas ───────────── -->
+      <div class="tab-panel hidden" id="tab-turmas" role="tabpanel">
+        <section class="kpi-grid" id="turmasKpis"></section>
+
+        <section class="chart-grid">
+          <div class="card">
+            <h2 class="card__title">Por modalidad</h2>
+            <canvas id="turmasModalityChart" height="140"></canvas>
+          </div>
+          <div class="card">
+            <h2 class="card__title">Por ciudad</h2>
+            <canvas id="turmasCityChart" height="140"></canvas>
+          </div>
+        </section>
+
+        <section class="card">
+          <h2 class="card__title">Alertas de ocupación</h2>
+          <div class="alert-grid">
+            <div class="alert-block alert-block--danger">
+              <div class="alert-block__title">Lleno / cuasi lleno (≥90%)</div>
+              <div id="overbookedList" class="alert-list"></div>
+            </div>
+            <div class="alert-block alert-block--warning">
+              <div class="alert-block__title">Pocos estudiantes (&lt;5)</div>
+              <div id="underbookedList" class="alert-list"></div>
+            </div>
+            <div class="alert-block alert-block--muted">
+              <div class="alert-block__title">Sin estudiantes</div>
+              <div id="emptyList" class="alert-list"></div>
+            </div>
+          </div>
+        </section>
+
+        <section class="card">
+          <h2 class="card__title">Todos los cursos</h2>
+          <div class="table-wrapper">
+            <table class="data-table" id="coursesTable">
+              <thead><tr>
+                <th>Curso</th><th>Nivel</th><th>Modalidad</th><th>Sede</th>
+                <th>Docente</th><th>Matrículas</th><th>Cupo</th><th>Ocupación</th>
+              </tr></thead>
+              <tbody></tbody>
+            </table>
+          </div>
+        </section>
+
+        <section class="card">
+          <h2 class="card__title">Docentes por carga</h2>
+          <div class="table-wrapper">
+            <table class="data-table" id="turmasTeachersTable">
+              <thead><tr>
+                <th>Nombre</th><th>Cursos</th><th>Estudiantes</th><th>Cupos totales</th>
+              </tr></thead>
+              <tbody></tbody>
+            </table>
+          </div>
+        </section>
+
+        <section class="card card--notes" id="turmasNotes"></section>
+      </div>
+
       <!-- ───────────── TAB: Financial ───────────── -->
       <div class="tab-panel hidden" id="tab-financial" role="tabpanel">
         <section class="kpi-grid" id="financialKpis"></section>
 
         <section class="card">
-          <h2 class="card__title">Ingresos mensuales (últimos 12 meses)</h2>
+          <h2 class="card__title">Ingresos por mes</h2>
           <canvas id="mrrChart" height="100"></canvas>
         </section>
 
         <section class="chart-grid">
           <div class="card">
+            <h2 class="card__title">Ingresos por modalidad</h2>
+            <canvas id="revenueByModalityChart" height="140"></canvas>
+          </div>
+          <div class="card">
             <h2 class="card__title">Ingresos por programa</h2>
             <canvas id="revenueByProgramChart" height="140"></canvas>
           </div>
+        </section>
+
+        <section class="chart-grid">
           <div class="card">
             <h2 class="card__title">Últimos pagos</h2>
             <div class="table-wrapper">
@@ -208,15 +399,14 @@
               </table>
             </div>
           </div>
-        </section>
-
-        <section class="card">
-          <h2 class="card__title">Top deudores (mayor saldo)</h2>
-          <div class="table-wrapper">
-            <table class="data-table" id="debtorsTable">
-              <thead><tr><th>Estudiante</th><th>Concepto</th><th>Período</th><th>Total</th><th>Pagado</th><th>Saldo</th></tr></thead>
-              <tbody></tbody>
-            </table>
+          <div class="card">
+            <h2 class="card__title">Top deudores</h2>
+            <div class="table-wrapper">
+              <table class="data-table" id="debtorsTable">
+                <thead><tr><th>Estudiante</th><th>Concepto</th><th>Período</th><th>Total</th><th>Pagado</th><th>Saldo</th></tr></thead>
+                <tbody></tbody>
+              </table>
+            </div>
           </div>
         </section>
       </div>

--- a/public/dashboard/index.html
+++ b/public/dashboard/index.html
@@ -470,6 +470,7 @@
     </main>
   </section>
 
+  <script src="/dashboard/helpers.js"></script>
   <script src="/dashboard/dashboard.js"></script>
 </body>
 </html>

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -8,6 +8,7 @@ import {
   UseGuards,
 } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
+import { Throttle } from '@nestjs/throttler';
 import type { Request, Response } from 'express';
 import { AuthService } from './auth.service';
 import { LoginDto } from './dto/login.dto';
@@ -23,6 +24,7 @@ export class AuthController {
   ) {}
 
   @Post('login')
+  @Throttle({ default: { limit: 5, ttl: 60_000 } })
   async login(
     @Body() dto: LoginDto,
     @Res({ passthrough: true }) res: Response,
@@ -31,7 +33,7 @@ export class AuthController {
     res.cookie(COOKIE_NAME, result.token, {
       httpOnly: true,
       secure: this.config.get('NODE_ENV') === 'production',
-      sameSite: 'lax',
+      sameSite: 'strict',
       maxAge: this.auth.cookieMaxAgeMs(),
       path: '/',
     });

--- a/src/q10/dashboard.controller.ts
+++ b/src/q10/dashboard.controller.ts
@@ -1,9 +1,19 @@
 import { Controller, Get, Post, Query, UseGuards } from '@nestjs/common';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+
+// Accept only plain YYYY-MM-DD to keep the /pagos passthrough to Q10 safe —
+// anything else (including ISO with time) gets dropped so the service falls
+// back to its `monthsBack`/`rangeDays` default.
+function validateIsoDate(v: unknown): string | undefined {
+  if (typeof v !== 'string') return undefined;
+  return /^\d{4}-\d{2}-\d{2}$/.test(v) ? v : undefined;
+}
+
 import { AcademicService } from './dashboard/academic.service';
 import { CommercialService } from './dashboard/commercial.service';
 import { CurrencyService } from './dashboard/currency.service';
 import { FinancialService } from './dashboard/financial.service';
+import { TurmasService } from './dashboard/turmas.service';
 import { DashboardService } from './dashboard.service';
 import { Q10ClientService } from './q10-client.service';
 
@@ -16,13 +26,18 @@ export class DashboardController {
     private readonly financial: FinancialService,
     private readonly commercial: CommercialService,
     private readonly currency: CurrencyService,
+    private readonly turmas: TurmasService,
     private readonly q10: Q10ClientService,
   ) {}
 
   @Get('overview')
-  overview(@Query('range') range?: string) {
+  overview(
+    @Query('range') range?: string,
+    @Query('from') from?: string,
+    @Query('to') to?: string,
+  ) {
     const days = Math.max(1, Math.min(365, Number(range ?? 30) || 30));
-    return this.dashboard.overview(days);
+    return this.dashboard.overview(days, validateIsoDate(from), validateIsoDate(to));
   }
 
   @Get('academic')
@@ -31,14 +46,23 @@ export class DashboardController {
   }
 
   @Get('financial')
-  financialView(@Query('months') months?: string) {
+  financialView(
+    @Query('months') months?: string,
+    @Query('from') from?: string,
+    @Query('to') to?: string,
+  ) {
     const n = Math.max(1, Math.min(60, Number(months ?? 12) || 12));
-    return this.financial.financial(n);
+    return this.financial.financial(n, validateIsoDate(from), validateIsoDate(to));
   }
 
   @Get('commercial')
   commercialView() {
     return this.commercial.commercial();
+  }
+
+  @Get('turmas')
+  turmasView() {
+    return this.turmas.turmas();
   }
 
   /**

--- a/src/q10/dashboard.service.ts
+++ b/src/q10/dashboard.service.ts
@@ -1,5 +1,6 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { Q10ClientService } from './q10-client.service';
+import { DashboardBaseService } from './dashboard/dashboard-base.service';
 import {
   cleanStr,
   currentlyActivePeriods,
@@ -7,31 +8,16 @@ import {
   Item,
   parseDate,
   periodKey,
-  safeArray,
   studentFullName,
   sum,
 } from './dashboard/helpers';
 
 @Injectable()
-export class DashboardService {
-  private readonly logger = new Logger(DashboardService.name);
+export class DashboardService extends DashboardBaseService {
+  protected readonly logPrefix = 'dashboard';
 
-  constructor(private readonly q10: Q10ClientService) {}
-
-  private async tryFetch<T>(
-    key: string,
-    path: string,
-    errors: Record<string, string>,
-    params?: Record<string, unknown>,
-  ): Promise<T[]> {
-    try {
-      return safeArray(await this.q10.getAll(path, params)) as T[];
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      errors[key] = message;
-      this.logger.warn(`[dashboard] ${path} failed: ${message}`);
-      return [];
-    }
+  constructor(q10: Q10ClientService) {
+    super(q10);
   }
 
   /**

--- a/src/q10/dashboard.service.ts
+++ b/src/q10/dashboard.service.ts
@@ -40,13 +40,24 @@ export class DashboardService {
    * Deeper drill-downs live on the sibling services: AcademicService,
    * FinancialService, CommercialService.
    */
-  async overview(rangeDays = 30) {
+  async overview(rangeDays = 30, fromIso?: string, toIso?: string) {
     const errors: Record<string, string> = {};
     const degraded: Record<string, string> = {};
     const ALL_TIME = { Fecha_inicio: '1900-01-01', Fecha_fin: '2099-12-31' };
 
-    const rangeEnd = new Date();
-    const rangeStart = new Date(Date.now() - rangeDays * 24 * 60 * 60 * 1000);
+    // When the dashboard sends explicit `from`/`to` (date picker presets
+    // like "Hoy" or "Este mes"), honour them — otherwise fall back to the
+    // legacy `rangeDays` behaviour. We recompute `rangeDays` from the
+    // actual window so downstream bucketing still lines up.
+    const parsedFrom = fromIso ? parseDate(fromIso) : null;
+    const parsedTo = toIso ? parseDate(toIso) : null;
+    const rangeEnd = parsedTo ?? new Date();
+    const rangeStart = parsedFrom ??
+      new Date(rangeEnd.getTime() - rangeDays * 24 * 60 * 60 * 1000);
+    const effectiveDays = Math.max(
+      1,
+      Math.ceil((rangeEnd.getTime() - rangeStart.getTime()) / (24 * 60 * 60 * 1000)) + 1,
+    );
     const RANGE = {
       Fecha_inicio: isoDate(rangeStart),
       Fecha_fin: isoDate(rangeEnd),
@@ -157,17 +168,24 @@ export class DashboardService {
       newStudentsInRange,
       'Fecha_matricula',
       null,
-      rangeDays,
+      rangeEnd,
+      effectiveDays,
     );
     const revenueByDay = this.bucketByDay(
       pagos,
       'Fecha_pago',
       'Valor_pagado',
-      rangeDays,
+      rangeEnd,
+      effectiveDays,
     );
 
     return {
-      range: { days: rangeDays, generatedAt: new Date().toISOString() },
+      range: {
+        days: effectiveDays,
+        from: isoDate(rangeStart),
+        to: isoDate(rangeEnd),
+        generatedAt: new Date().toISOString(),
+      },
       partial: Object.keys(errors).length > 0,
       errors,
       degraded,
@@ -228,11 +246,13 @@ export class DashboardService {
     list: Item[],
     dateField: string,
     valueField: string | null,
+    rangeEnd: Date,
     days: number,
   ): Array<{ date: string; value: number }> {
     const buckets = new Map<string, number>();
+    const endTime = rangeEnd.getTime();
     for (let i = days - 1; i >= 0; i--) {
-      const d = new Date(Date.now() - i * 24 * 60 * 60 * 1000);
+      const d = new Date(endTime - i * 24 * 60 * 60 * 1000);
       buckets.set(d.toISOString().slice(0, 10), 0);
     }
     for (const item of list) {

--- a/src/q10/dashboard/academic.service.ts
+++ b/src/q10/dashboard/academic.service.ts
@@ -1,5 +1,6 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { Q10ClientService } from '../q10-client.service';
+import { DashboardBaseService } from './dashboard-base.service';
 import {
   ageBucket,
   ageFromBirthdate,
@@ -15,30 +16,15 @@ import {
   monthsBetween,
   periodKey,
   previousPeriod,
-  safeArray,
   studentFullName,
 } from './helpers';
 
 @Injectable()
-export class AcademicService {
-  private readonly logger = new Logger(AcademicService.name);
+export class AcademicService extends DashboardBaseService {
+  protected readonly logPrefix = 'academic';
 
-  constructor(private readonly q10: Q10ClientService) {}
-
-  private async tryFetch<T>(
-    key: string,
-    path: string,
-    errors: Record<string, string>,
-    params?: Record<string, unknown>,
-  ): Promise<T[]> {
-    try {
-      return safeArray(await this.q10.getAll(path, params)) as T[];
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      errors[key] = message;
-      this.logger.warn(`[academic] ${path} failed: ${message}`);
-      return [];
-    }
+  constructor(q10: Q10ClientService) {
+    super(q10);
   }
 
   /**

--- a/src/q10/dashboard/academic.service.ts
+++ b/src/q10/dashboard/academic.service.ts
@@ -4,26 +4,23 @@ import { DashboardBaseService } from './dashboard-base.service';
 import {
   ageBucket,
   ageFromBirthdate,
-  cefrIndex,
   CEFR_LEVELS,
   classifyModality,
   cleanStr,
   currentlyActivePeriods,
-  expectedLevelAdvance,
   groupCount,
   Item,
   Modality,
-  monthsBetween,
   periodKey,
   previousPeriod,
-  studentFullName,
 } from './helpers';
+import { RiskAnalysisService } from './risk-analysis.service';
 
 @Injectable()
 export class AcademicService extends DashboardBaseService {
   protected readonly logPrefix = 'academic';
 
-  constructor(q10: Q10ClientService) {
+  constructor(q10: Q10ClientService, private readonly risk: RiskAnalysisService) {
     super(q10);
   }
 
@@ -108,11 +105,13 @@ export class AcademicService extends DashboardBaseService {
     // This endpoint consolidates what /inasistencias should have returned
     // (empty on this tenant) — Cantidad_inasistencia is available here per
     // student-asignatura pairing. Best fallback for attendance signal.
+    // Cap at 20k: /evaluaciones produces one row per student-asignatura pair and grows fastest.
     const evaluations = await this.tryFetch<Item>(
       'evaluations',
       '/evaluaciones',
       errors,
       { Programa: '01' },
+      { maxRecords: 20_000, degraded },
     );
     const evalByStudent = new Map<string, Item[]>();
     for (const e of evaluations) {
@@ -175,44 +174,8 @@ export class AcademicService extends DashboardBaseService {
     }
     const avgAge = ages.length > 0 ? Math.round(ages.reduce((a, b) => a + b, 0) / ages.length) : null;
 
-    // ─── Risk flags — high-inasistencia, low-grade, level-stalled ───
-    // Threshold choices are conservative defaults; operators can refine once
-    // they eyeball real data.
-    const ABSENCE_THRESHOLD = 20;    // % inasistencia above which we flag
-    const GRADE_THRESHOLD = 0.6;     // Promedio_evaluacion below which we flag
-    const STALL_MULTIPLIER = 1.5;    // behind expected progression × this = stalled
-
-    const riskFlags = enriched
-      .map(({ student, modality, inasistencia, promedio, cursoNombre }) => {
-        const months = monthsBetween(student.Fecha_matricula) ?? 0;
-        const expectedIdx = modality === 'Desconocida'
-          ? null
-          : expectedLevelAdvance(modality, months);
-        const currentIdx = cefrIndex(student.Nombre_nivel);
-        const behindLevels = expectedIdx !== null && currentIdx !== null
-          ? Math.max(0, expectedIdx - currentIdx)
-          : 0;
-        const flags: string[] = [];
-        if (inasistencia > ABSENCE_THRESHOLD) flags.push(`${Math.round(inasistencia)}% faltas`);
-        if (promedio > 0 && promedio < GRADE_THRESHOLD) flags.push(`nota ${promedio.toFixed(2)}`);
-        if (modality !== 'Desconocida' && months >= STALL_MULTIPLIER * 3 && behindLevels > 0) {
-          flags.push(`${behindLevels} nivel(es) atrás del esperado`);
-        }
-        if (flags.length === 0) return null;
-        return {
-          Codigo: cleanStr(student.Codigo_estudiante),
-          nombre: studentFullName(student) || '—',
-          nivel: cleanStr(student.Nombre_nivel),
-          modality,
-          curso: cursoNombre || '—',
-          mesesMatriculado: months,
-          inasistencia: Math.round(inasistencia),
-          promedio,
-          flags,
-        };
-      })
-      .filter((r): r is NonNullable<typeof r> => r !== null)
-      .sort((a, b) => b.flags.length - a.flags.length || b.inasistencia - a.inasistencia);
+    // ─── Risk flags — delegated to RiskAnalysisService ───
+    const riskFlags = this.risk.computeRiskFlags(enriched).slice(0, 30);
 
     return {
       generatedAt: new Date().toISOString(),
@@ -252,7 +215,7 @@ export class AcademicService extends DashboardBaseService {
           (e) => cleanStr(e.student.Nombre_nivel) || 'Sin nivel',
         ),
       },
-      riskFlags: riskFlags.slice(0, 30),
+      riskFlags,
       teachers: docentes.slice(0, 20).map((d) => ({
         Codigo: cleanStr(d.Codigo),
         Nombres: [d.Primer_nombre, d.Segundo_nombre].map(cleanStr).filter(Boolean).join(' '),

--- a/src/q10/dashboard/academic.service.ts
+++ b/src/q10/dashboard/academic.service.ts
@@ -3,13 +3,20 @@ import { Q10ClientService } from '../q10-client.service';
 import {
   ageBucket,
   ageFromBirthdate,
+  cefrIndex,
+  CEFR_LEVELS,
+  classifyModality,
   cleanStr,
   currentlyActivePeriods,
+  expectedLevelAdvance,
   groupCount,
   Item,
+  Modality,
+  monthsBetween,
   periodKey,
   previousPeriod,
   safeArray,
+  studentFullName,
 } from './helpers';
 
 @Injectable()
@@ -111,11 +118,56 @@ export class AcademicService {
       churnRate: prevIds.size > 0 ? Math.round((churned.length / prevIds.size) * 100) : null,
     };
 
+    // ─── Pull /evaluaciones for faltas + promedio by student ───
+    // This endpoint consolidates what /inasistencias should have returned
+    // (empty on this tenant) — Cantidad_inasistencia is available here per
+    // student-asignatura pairing. Best fallback for attendance signal.
+    const evaluations = await this.tryFetch<Item>(
+      'evaluations',
+      '/evaluaciones',
+      errors,
+      { Programa: '01' },
+    );
+    const evalByStudent = new Map<string, Item[]>();
+    for (const e of evaluations) {
+      const id = cleanStr(e.Codigo_estudiante);
+      if (!id) continue;
+      if (!evalByStudent.has(id)) evalByStudent.set(id, []);
+      evalByStudent.get(id)!.push(e);
+    }
+
+    // ─── Join students with their course/modality via /evaluaciones ───
+    // Each student can have multiple asignatura rows (they matriculate in
+    // several parallel modules). We pick the most recent / primary one by
+    // assuming the row with the highest Consecutivo_curso is their active
+    // class, then classify modality from its Nombre_curso.
+    const enriched = currentStudents.map((s) => {
+      const id = cleanStr(s.Codigo_estudiante);
+      const evals = evalByStudent.get(id) ?? [];
+      // Primary curso: the one with the highest Porcentaje_evaluado so far
+      // (= their active/current module).
+      const primary = evals.slice().sort(
+        (a, b) => (Number(b.Porcentaje_evaluado) || 0) - (Number(a.Porcentaje_evaluado) || 0),
+      )[0];
+      const modality: Modality = primary
+        ? classifyModality(primary.Nombre_curso)
+        : 'Desconocida';
+      const inasistencia = primary ? Number(primary.Porcentaje_inasistencia) || 0 : 0;
+      const promedio = primary ? Number(primary.Promedio_evaluacion) || 0 : 0;
+      const cursoNombre = primary ? cleanStr(primary.Nombre_curso) : '';
+      return { student: s, modality, inasistencia, promedio, cursoNombre, primary };
+    });
+
     // ─── Distributions ───
     const byJornada = groupCount(currentStudents, (s) => s.Nombre_jornada);
     const byNivel = groupCount(currentStudents, (s) => s.Nombre_nivel);
     const bySedeJornada = groupCount(currentStudents, (s) => s.Nombre_sedejornada);
-    const byProgram = groupCount(currentStudents, (s) => s.Nombre_programa);
+    const byModality = groupCount(enriched, (e) => e.modality);
+    // City-class derived from "NN R - Cidade" pattern in Nombre_curso.
+    const byCity = groupCount(enriched, (e) => {
+      const m = e.cursoNombre.match(/-\s*(.+)$/);
+      return m ? m[1].trim() : 'Sin clase asignada';
+    });
     const byCondicion = groupCount(currentStudents, (s) =>
       cleanStr(s.Condicion_matricula) || 'Sin dato',
     );
@@ -137,6 +189,45 @@ export class AcademicService {
     }
     const avgAge = ages.length > 0 ? Math.round(ages.reduce((a, b) => a + b, 0) / ages.length) : null;
 
+    // ─── Risk flags — high-inasistencia, low-grade, level-stalled ───
+    // Threshold choices are conservative defaults; operators can refine once
+    // they eyeball real data.
+    const ABSENCE_THRESHOLD = 20;    // % inasistencia above which we flag
+    const GRADE_THRESHOLD = 0.6;     // Promedio_evaluacion below which we flag
+    const STALL_MULTIPLIER = 1.5;    // behind expected progression × this = stalled
+
+    const riskFlags = enriched
+      .map(({ student, modality, inasistencia, promedio, cursoNombre }) => {
+        const months = monthsBetween(student.Fecha_matricula) ?? 0;
+        const expectedIdx = modality === 'Desconocida'
+          ? null
+          : expectedLevelAdvance(modality, months);
+        const currentIdx = cefrIndex(student.Nombre_nivel);
+        const behindLevels = expectedIdx !== null && currentIdx !== null
+          ? Math.max(0, expectedIdx - currentIdx)
+          : 0;
+        const flags: string[] = [];
+        if (inasistencia > ABSENCE_THRESHOLD) flags.push(`${Math.round(inasistencia)}% faltas`);
+        if (promedio > 0 && promedio < GRADE_THRESHOLD) flags.push(`nota ${promedio.toFixed(2)}`);
+        if (modality !== 'Desconocida' && months >= STALL_MULTIPLIER * 3 && behindLevels > 0) {
+          flags.push(`${behindLevels} nivel(es) atrás del esperado`);
+        }
+        if (flags.length === 0) return null;
+        return {
+          Codigo: cleanStr(student.Codigo_estudiante),
+          nombre: studentFullName(student) || '—',
+          nivel: cleanStr(student.Nombre_nivel),
+          modality,
+          curso: cursoNombre || '—',
+          mesesMatriculado: months,
+          inasistencia: Math.round(inasistencia),
+          promedio,
+          flags,
+        };
+      })
+      .filter((r): r is NonNullable<typeof r> => r !== null)
+      .sort((a, b) => b.flags.length - a.flags.length || b.inasistencia - a.inasistencia);
+
     return {
       generatedAt: new Date().toISOString(),
       partial: Object.keys(errors).length > 0,
@@ -147,17 +238,35 @@ export class AcademicService {
         totalTeachers: docentes.length,
         avgAge,
         currentPeriod: retention.currentPeriod,
+        atRiskCount: riskFlags.length,
+        regularCount: byModality['Regular'] ?? 0,
+        intensivoCount: byModality['Semi Intensivo'] ?? 0,
+        unclassifiedCount: byModality['Desconocida'] ?? 0,
       },
       retention,
       distributions: {
         byJornada,
         byNivel,
         bySedeJornada,
-        byProgram,
+        byModality,
+        byCity,
         byCondicion,
         byGender: gender,
         byAge: ageDistribution,
       },
+      // CEFR progression stats — only among classified students.
+      progression: {
+        levelsOrder: [...CEFR_LEVELS],
+        distributionRegular: groupCount(
+          enriched.filter((e) => e.modality === 'Regular'),
+          (e) => cleanStr(e.student.Nombre_nivel) || 'Sin nivel',
+        ),
+        distributionIntensivo: groupCount(
+          enriched.filter((e) => e.modality === 'Semi Intensivo'),
+          (e) => cleanStr(e.student.Nombre_nivel) || 'Sin nivel',
+        ),
+      },
+      riskFlags: riskFlags.slice(0, 30),
       teachers: docentes.slice(0, 20).map((d) => ({
         Codigo: cleanStr(d.Codigo),
         Nombres: [d.Primer_nombre, d.Segundo_nombre].map(cleanStr).filter(Boolean).join(' '),

--- a/src/q10/dashboard/commercial.service.ts
+++ b/src/q10/dashboard/commercial.service.ts
@@ -1,34 +1,20 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { Q10ClientService } from '../q10-client.service';
+import { DashboardBaseService } from './dashboard-base.service';
 import {
   cleanStr,
   groupCount,
   Item,
   monthKey,
   parseDate,
-  safeArray,
 } from './helpers';
 
 @Injectable()
-export class CommercialService {
-  private readonly logger = new Logger(CommercialService.name);
+export class CommercialService extends DashboardBaseService {
+  protected readonly logPrefix = 'commercial';
 
-  constructor(private readonly q10: Q10ClientService) {}
-
-  private async tryFetch<T>(
-    key: string,
-    path: string,
-    errors: Record<string, string>,
-    params?: Record<string, unknown>,
-  ): Promise<T[]> {
-    try {
-      return safeArray(await this.q10.getAll(path, params)) as T[];
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      errors[key] = message;
-      this.logger.warn(`[commercial] ${path} failed: ${message}`);
-      return [];
-    }
+  constructor(q10: Q10ClientService) {
+    super(q10);
   }
 
   /**

--- a/src/q10/dashboard/dashboard-base.service.ts
+++ b/src/q10/dashboard/dashboard-base.service.ts
@@ -1,0 +1,28 @@
+import { Logger } from '@nestjs/common';
+import { Q10ClientService } from '../q10-client.service';
+import { safeArray } from './helpers';
+
+export abstract class DashboardBaseService {
+  protected abstract readonly logPrefix: string;
+  protected readonly logger: Logger;
+
+  constructor(protected readonly q10: Q10ClientService) {
+    this.logger = new Logger(this.constructor.name);
+  }
+
+  protected async tryFetch<T>(
+    key: string,
+    path: string,
+    errors: Record<string, string>,
+    params?: Record<string, unknown>,
+  ): Promise<T[]> {
+    try {
+      return safeArray(await this.q10.getAll(path, params)) as T[];
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      errors[key] = message;
+      this.logger.warn(`[${this.logPrefix}] ${path} failed: ${message}`);
+      return [];
+    }
+  }
+}

--- a/src/q10/dashboard/dashboard-base.service.ts
+++ b/src/q10/dashboard/dashboard-base.service.ts
@@ -15,9 +15,20 @@ export abstract class DashboardBaseService {
     path: string,
     errors: Record<string, string>,
     params?: Record<string, unknown>,
+    opts?: { pageSize?: number; maxRecords?: number; degraded?: Record<string, string> },
   ): Promise<T[]> {
     try {
-      return safeArray(await this.q10.getAll(path, params)) as T[];
+      const out = safeArray(
+        await this.q10.getAll(path, params, {
+          pageSize: opts?.pageSize,
+          maxRecords: opts?.maxRecords,
+        }),
+      ) as T[];
+      const cap = opts?.maxRecords ?? 50_000;
+      if (out.length === cap && opts?.degraded) {
+        opts.degraded[key] = `Posible truncamiento — límite de ${cap} registros alcanzado`;
+      }
+      return out;
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       errors[key] = message;

--- a/src/q10/dashboard/financial.service.ts
+++ b/src/q10/dashboard/financial.service.ts
@@ -1,11 +1,13 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { Q10ClientService } from '../q10-client.service';
 import {
+  classifyModality,
   cleanStr,
   currentlyActivePeriods,
   groupSum,
   isoDate,
   Item,
+  Modality,
   monthKey,
   parseDate,
   periodKey,
@@ -45,14 +47,34 @@ export class FinancialService {
    * "no aplica al modelo financiero correspondiente". Reconciliation is
    * done by intersecting /pagos.Codigo_persona with /estudiantes
    * .Codigo_estudiante (both are the same 12-digit internal person code).
+   *
+   * `from`/`to` are optional ISO dates — when provided, they override the
+   * `monthsBack` preset. The dashboard's date picker (Hoy / Últimos 7 /
+   * Este mes / fecha seleccionada) sends them straight through.
    */
-  async financial(monthsBack = 12) {
+  async financial(monthsBack = 12, from?: string, to?: string) {
     const errors: Record<string, string> = {};
     const degraded: Record<string, string> = {};
 
-    const now = new Date();
-    const rangeStart = new Date(now);
-    rangeStart.setMonth(rangeStart.getMonth() - monthsBack);
+    const now = to ? (parseDate(to) ?? new Date()) : new Date();
+    const parsedFrom = from ? parseDate(from) : null;
+    const rangeStart = parsedFrom ?? (() => {
+      const d = new Date(now);
+      d.setMonth(d.getMonth() - monthsBack);
+      return d;
+    })();
+
+    // `windowMonths` drives how many MRR buckets we emit. When the caller
+    // passes an explicit `from`, we recompute from the actual span; otherwise
+    // we keep `monthsBack` verbatim so the bucket count matches the request
+    // exactly (the e2e test asserts `months=6` → 6 buckets).
+    const windowMonths = parsedFrom
+      ? Math.max(
+          1,
+          ((now.getFullYear() - rangeStart.getFullYear()) * 12 +
+            (now.getMonth() - rangeStart.getMonth())) + 1,
+        )
+      : monthsBack;
 
     const [periodos, pagos] = await Promise.all([
       this.tryFetch<Item>('periods', '/periodos', errors),
@@ -97,7 +119,7 @@ export class FinancialService {
 
     // ─── MRR monthly trend ───
     const revenueByMonth: Record<string, number> = {};
-    for (let i = monthsBack - 1; i >= 0; i--) {
+    for (let i = windowMonths - 1; i >= 0; i--) {
       const d = new Date(now);
       d.setMonth(d.getMonth() - i);
       revenueByMonth[monthKey(d)] = 0;
@@ -174,6 +196,24 @@ export class FinancialService {
       'Valor_pagado',
     );
 
+    // ─── Revenue segmented by modality (Regular / Semi Intensivo) ───
+    // /pagos doesn't carry Nombre_curso, but it does carry Nombre_producto
+    // which is shaped like "Mensualidad 14 R - Recife". classifyModality()
+    // handles both shapes (product name or course name) since the pattern
+    // is identical. Payments whose product doesn't match land in
+    // "Desconocida" — useful to spot concepts like "Matrícula" that are
+    // modality-agnostic.
+    const revenueByModality: Record<Modality, number> = {
+      Regular: 0,
+      'Semi Intensivo': 0,
+      Desconocida: 0,
+    };
+    for (const p of pagos) {
+      const label = cleanStr(p.Nombre_producto) || cleanStr(p.Nombre_programa);
+      const m = classifyModality(label);
+      revenueByModality[m] += Number(p.Valor_pagado) || 0;
+    }
+
     const recentPayments = pagos
       .slice()
       .sort((a, b) => {
@@ -197,6 +237,9 @@ export class FinancialService {
       degraded,
       summary: {
         monthsBack,
+        windowMonths,
+        from: isoDate(rangeStart),
+        to: isoDate(now),
         totalRevenue,
         outstandingDebt,
         payingStudents: payingTotals.length,
@@ -206,10 +249,14 @@ export class FinancialService {
         avgTicket: Math.round(avgTicket * 100) / 100,
         ltvApprox: Math.round(ltvApprox * 100) / 100,
         maxPaid,
+        revenueRegular: revenueByModality.Regular,
+        revenueIntensivo: revenueByModality['Semi Intensivo'],
+        revenueUnclassified: revenueByModality.Desconocida,
       },
       charts: {
         revenueByMonth: revenueSeries,
         revenueByConcept,
+        revenueByModality,
       },
       tables: {
         topDebtors,

--- a/src/q10/dashboard/financial.service.ts
+++ b/src/q10/dashboard/financial.service.ts
@@ -1,5 +1,6 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { Q10ClientService } from '../q10-client.service';
+import { DashboardBaseService } from './dashboard-base.service';
 import {
   classifyModality,
   cleanStr,
@@ -11,31 +12,16 @@ import {
   monthKey,
   parseDate,
   periodKey,
-  safeArray,
   studentFullName,
   sum,
 } from './helpers';
 
 @Injectable()
-export class FinancialService {
-  private readonly logger = new Logger(FinancialService.name);
+export class FinancialService extends DashboardBaseService {
+  protected readonly logPrefix = 'financial';
 
-  constructor(private readonly q10: Q10ClientService) {}
-
-  private async tryFetch<T>(
-    key: string,
-    path: string,
-    errors: Record<string, string>,
-    params?: Record<string, unknown>,
-  ): Promise<T[]> {
-    try {
-      return safeArray(await this.q10.getAll(path, params)) as T[];
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      errors[key] = message;
-      this.logger.warn(`[financial] ${path} failed: ${message}`);
-      return [];
-    }
+  constructor(q10: Q10ClientService) {
+    super(q10);
   }
 
   /**

--- a/src/q10/dashboard/financial.service.ts
+++ b/src/q10/dashboard/financial.service.ts
@@ -62,12 +62,19 @@ export class FinancialService extends DashboardBaseService {
         )
       : monthsBack;
 
+    // Cap /pagos at 20k: payment rows grow unbounded over long date ranges.
     const [periodos, pagos] = await Promise.all([
       this.tryFetch<Item>('periods', '/periodos', errors),
-      this.tryFetch<Item>('payments', '/pagos', errors, {
-        Fecha_inicio: isoDate(rangeStart),
-        Fecha_fin: isoDate(now),
-      }),
+      this.tryFetch<Item>(
+        'payments',
+        '/pagos',
+        errors,
+        {
+          Fecha_inicio: isoDate(rangeStart),
+          Fecha_fin: isoDate(now),
+        },
+        { maxRecords: 20_000, degraded },
+      ),
     ]);
 
     const active = currentlyActivePeriods(periodos);

--- a/src/q10/dashboard/helpers.ts
+++ b/src/q10/dashboard/helpers.ts
@@ -146,3 +146,61 @@ export function ageBucket(age: number): string {
   if (age < 65) return '50-64';
   return '65+';
 }
+
+// ═══════════════════════════════════════════════════════════════════
+// Genius-specific business rules
+// ═══════════════════════════════════════════════════════════════════
+
+/** CEFR progression — order matters for "expected level after N months". */
+export const CEFR_LEVELS = ['A1', 'A2', 'B1', 'B2', 'C1', 'C2'] as const;
+export type CefrLevel = (typeof CEFR_LEVELS)[number];
+
+/** Months each modality takes to advance one CEFR level at Genius.
+ *  Confirmed by the operator: Regular = 3 months/level, Intensivo = 1.5. */
+export const MONTHS_PER_LEVEL = { Regular: 3, 'Semi Intensivo': 1.5 } as const;
+
+export type Modality = 'Regular' | 'Semi Intensivo' | 'Desconocida';
+
+/**
+ * Classify a course's modality from its `Nombre_curso`. Pattern observed in
+ * the live Q10 tenant: "NN R - City" (Regular) and "NN S - City"
+ * (Semi Intensivo) — confirmed across 10 sample courses. "Desconocida"
+ * covers anything that doesn't match, so the UI can bucket those into
+ * "Sin clasificar" without crashing.
+ */
+export function classifyModality(nombreCurso: unknown): Modality {
+  const s = cleanStr(nombreCurso);
+  if (/\s(R|Regular)\s*-/i.test(s)) return 'Regular';
+  if (/\s(S|Semi\s*Intensivo|Intensivo)\s*-/i.test(s)) return 'Semi Intensivo';
+  return 'Desconocida';
+}
+
+/**
+ * Index of a CEFR level (A1=0 … C2=5). Returns null if the string isn't a
+ * recognised CEFR code; callers skip those from progression math.
+ */
+export function cefrIndex(nivel: unknown): number | null {
+  const s = cleanStr(nivel).toUpperCase();
+  const i = (CEFR_LEVELS as readonly string[]).indexOf(s);
+  return i === -1 ? null : i;
+}
+
+/**
+ * How many CEFR levels a student should have advanced after `months` at the
+ * given modality, rounded down. A student Regular at month 7 should be in
+ * level index 2 (A1 → A2 → B1 → started B1).
+ */
+export function expectedLevelAdvance(modality: Modality, months: number): number {
+  const m = MONTHS_PER_LEVEL[modality as keyof typeof MONTHS_PER_LEVEL];
+  if (!m || months <= 0) return 0;
+  return Math.floor(months / m);
+}
+
+/** Months between two dates (ISO strings or Date), rounded to one decimal. */
+export function monthsBetween(from: unknown, to: unknown = new Date()): number | null {
+  const a = parseDate(from);
+  const b = to instanceof Date ? to : parseDate(to);
+  if (!a || !b) return null;
+  const ms = b.getTime() - a.getTime();
+  return Math.round((ms / (1000 * 60 * 60 * 24 * 30.44)) * 10) / 10;
+}

--- a/src/q10/dashboard/risk-analysis.service.ts
+++ b/src/q10/dashboard/risk-analysis.service.ts
@@ -1,0 +1,93 @@
+import { Injectable } from '@nestjs/common';
+import {
+  cefrIndex,
+  cleanStr,
+  expectedLevelAdvance,
+  Item,
+  Modality,
+  monthsBetween,
+  studentFullName,
+} from './helpers';
+
+/**
+ * Thresholds for flagging at-risk students. Exported so tuning lives in a
+ * single place and can be referenced from tests / docs if needed.
+ */
+export const ABSENCE_THRESHOLD = 20;   // % inasistencia above which we flag
+export const GRADE_THRESHOLD = 0.6;    // Promedio_evaluacion below which we flag
+export const STALL_MULTIPLIER = 1.5;   // behind expected progression × this = stalled
+
+/**
+ * Shape produced by the enrichment step in AcademicService. Kept loose on
+ * `primary` because this service doesn't consume that field — it's included
+ * for symmetry with the caller's type.
+ */
+export interface EnrichedStudent {
+  student: Item;
+  modality: Modality;
+  inasistencia: number;
+  promedio: number;
+  cursoNombre: string;
+  primary?: Item;
+}
+
+export interface RiskFlag {
+  Codigo: string;
+  nombre: string;
+  nivel: string;
+  modality: Modality;
+  curso: string;
+  mesesMatriculado: number;
+  inasistencia: number;
+  promedio: number;
+  flags: string[];
+}
+
+@Injectable()
+export class RiskAnalysisService {
+  static readonly ABSENCE_THRESHOLD = ABSENCE_THRESHOLD;
+  static readonly GRADE_THRESHOLD = GRADE_THRESHOLD;
+  static readonly STALL_MULTIPLIER = STALL_MULTIPLIER;
+
+  /**
+   * Compute risk flags for the enriched student list. Pure function — no I/O,
+   * no DI beyond the class itself. Returns the full sorted list; the caller
+   * is responsible for slicing (e.g. top-N for the API payload).
+   *
+   * Sort order: by flag count desc, ties broken by inasistencia desc — matches
+   * the previous inline behavior in AcademicService.
+   */
+  computeRiskFlags(enriched: EnrichedStudent[]): RiskFlag[] {
+    return enriched
+      .map(({ student, modality, inasistencia, promedio, cursoNombre }) => {
+        const months = monthsBetween(student.Fecha_matricula) ?? 0;
+        const expectedIdx =
+          modality === 'Desconocida' ? null : expectedLevelAdvance(modality, months);
+        const currentIdx = cefrIndex(student.Nombre_nivel);
+        const behindLevels =
+          expectedIdx !== null && currentIdx !== null
+            ? Math.max(0, expectedIdx - currentIdx)
+            : 0;
+        const flags: string[] = [];
+        if (inasistencia > ABSENCE_THRESHOLD) flags.push(`${Math.round(inasistencia)}% faltas`);
+        if (promedio > 0 && promedio < GRADE_THRESHOLD) flags.push(`nota ${promedio.toFixed(2)}`);
+        if (modality !== 'Desconocida' && months >= STALL_MULTIPLIER * 3 && behindLevels > 0) {
+          flags.push(`${behindLevels} nivel(es) atrás del esperado`);
+        }
+        if (flags.length === 0) return null;
+        return {
+          Codigo: cleanStr(student.Codigo_estudiante),
+          nombre: studentFullName(student) || '—',
+          nivel: cleanStr(student.Nombre_nivel),
+          modality,
+          curso: cursoNombre || '—',
+          mesesMatriculado: months,
+          inasistencia: Math.round(inasistencia),
+          promedio,
+          flags,
+        } satisfies RiskFlag;
+      })
+      .filter((r): r is RiskFlag => r !== null)
+      .sort((a, b) => b.flags.length - a.flags.length || b.inasistencia - a.inasistencia);
+  }
+}

--- a/src/q10/dashboard/turmas.service.ts
+++ b/src/q10/dashboard/turmas.service.ts
@@ -50,9 +50,13 @@ export class TurmasService extends DashboardBaseService {
     const errors: Record<string, string> = {};
     const degraded: Record<string, string> = {};
 
+    // Cap /cursos at 5k: course catalog is bounded, conservative safety limit.
     const [periodos, cursos] = await Promise.all([
       this.tryFetch<Item>('periods', '/periodos', errors),
-      this.tryFetch<Item>('courses', '/cursos', errors),
+      this.tryFetch<Item>('courses', '/cursos', errors, undefined, {
+        maxRecords: 5_000,
+        degraded,
+      }),
     ]);
 
     const active = currentlyActivePeriods(periodos);

--- a/src/q10/dashboard/turmas.service.ts
+++ b/src/q10/dashboard/turmas.service.ts
@@ -1,5 +1,6 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { Q10ClientService } from '../q10-client.service';
+import { DashboardBaseService } from './dashboard-base.service';
 import {
   classifyModality,
   cleanStr,
@@ -8,7 +9,6 @@ import {
   Item,
   Modality,
   periodKey,
-  safeArray,
 } from './helpers';
 
 // /cursos reports Estado as "Abierto" / "Cerrado" / "Finalizado" — not the
@@ -35,29 +35,15 @@ function isOpenCourse(estado: unknown): boolean {
  * modality === 'Desconocida' + Nombre_pensum.
  */
 @Injectable()
-export class TurmasService {
-  private readonly logger = new Logger(TurmasService.name);
+export class TurmasService extends DashboardBaseService {
+  protected readonly logPrefix = 'turmas';
 
   // Thresholds chosen by conservation — easy to tune once real data lands.
   private readonly UNDERBOOKED_ABSOLUTE = 5;   // < 5 students = subutilized
   private readonly OVERBOOKED_PERCENT = 90;    // >= 90% cupo = quase cheio
 
-  constructor(private readonly q10: Q10ClientService) {}
-
-  private async tryFetch<T>(
-    key: string,
-    path: string,
-    errors: Record<string, string>,
-    params?: Record<string, unknown>,
-  ): Promise<T[]> {
-    try {
-      return safeArray(await this.q10.getAll(path, params)) as T[];
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      errors[key] = message;
-      this.logger.warn(`[turmas] ${path} failed: ${message}`);
-      return [];
-    }
+  constructor(q10: Q10ClientService) {
+    super(q10);
   }
 
   async turmas() {

--- a/src/q10/dashboard/turmas.service.ts
+++ b/src/q10/dashboard/turmas.service.ts
@@ -1,0 +1,209 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Q10ClientService } from '../q10-client.service';
+import {
+  classifyModality,
+  cleanStr,
+  currentlyActivePeriods,
+  groupCount,
+  Item,
+  Modality,
+  periodKey,
+  safeArray,
+} from './helpers';
+
+// /cursos reports Estado as "Abierto" / "Cerrado" / "Finalizado" — not the
+// Activo/Inactivo that /periodos and /estudiantes use. `isActivo` from
+// helpers would reject every open course, so we match the /cursos vocabulary
+// explicitly here.
+const OPEN_COURSE_STATES = new Set(['abierto', 'abierta', 'activo', 'active', 'true', '1']);
+function isOpenCourse(estado: unknown): boolean {
+  if (estado === true) return true;
+  return OPEN_COURSE_STATES.has(cleanStr(estado).toLowerCase());
+}
+
+/**
+ * Turmas (course sections) view — built on top of /cursos, which turned out
+ * to be the "gold" endpoint for this tenant. Each course record ships with
+ * Cupo_maximo + Cantidad_estudiantes_matriculados, so we can compute the
+ * one metric the operator actually asked for (ocupação) without crawling
+ * /estudiantes for every class.
+ *
+ * Alerting is intentionally simple — the operator will refine thresholds
+ * once they've stared at real numbers for a week. Particulares are not
+ * cadastradas in Q10 yet (confirmed with the user); once they are, they'll
+ * surface here automatically via /cursos and we'll split them out by
+ * modality === 'Desconocida' + Nombre_pensum.
+ */
+@Injectable()
+export class TurmasService {
+  private readonly logger = new Logger(TurmasService.name);
+
+  // Thresholds chosen by conservation — easy to tune once real data lands.
+  private readonly UNDERBOOKED_ABSOLUTE = 5;   // < 5 students = subutilized
+  private readonly OVERBOOKED_PERCENT = 90;    // >= 90% cupo = quase cheio
+
+  constructor(private readonly q10: Q10ClientService) {}
+
+  private async tryFetch<T>(
+    key: string,
+    path: string,
+    errors: Record<string, string>,
+    params?: Record<string, unknown>,
+  ): Promise<T[]> {
+    try {
+      return safeArray(await this.q10.getAll(path, params)) as T[];
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      errors[key] = message;
+      this.logger.warn(`[turmas] ${path} failed: ${message}`);
+      return [];
+    }
+  }
+
+  async turmas() {
+    const errors: Record<string, string> = {};
+    const degraded: Record<string, string> = {};
+
+    const [periodos, cursos] = await Promise.all([
+      this.tryFetch<Item>('periods', '/periodos', errors),
+      this.tryFetch<Item>('courses', '/cursos', errors),
+    ]);
+
+    const active = currentlyActivePeriods(periodos);
+    const activeKeys = new Set(active.map((p) => periodKey(p)));
+
+    // Only consider courses in an active period AND with Estado = Abierto.
+    // Q10 keeps historic courses (Cerrado/Finalizado) in the same endpoint;
+    // the Turmas tab is about *what's happening now*.
+    const currentCourses = cursos.filter((c) => {
+      const period = cleanStr(c.Consecutivo_periodo);
+      const matchesPeriod = activeKeys.size === 0 || activeKeys.has(period);
+      return matchesPeriod && isOpenCourse(c.Estado);
+    });
+
+    if (currentCourses.length === 0 && cursos.length > 0) {
+      degraded.currentCourses = 'No hay cursos en estado activo para los períodos vigentes';
+    }
+
+    const enriched = currentCourses.map((c) => {
+      const cupo = Number(c.Cupo_maximo) || 0;
+      const matriculados = Number(c.Cantidad_estudiantes_matriculados) || 0;
+      const ocupacion = cupo > 0 ? Math.round((matriculados / cupo) * 100) : null;
+      const modality: Modality = classifyModality(c.Nombre);
+      // "NN X - City" → "City" (may be undefined if the pattern doesn't match).
+      const cityMatch = cleanStr(c.Nombre).match(/-\s*(.+)$/);
+      const city = cityMatch ? cityMatch[1].trim() : 'Sin clase asignada';
+      return {
+        Codigo: cleanStr(c.Codigo),
+        Consecutivo: cleanStr(c.Consecutivo),
+        Nombre: cleanStr(c.Nombre),
+        Nivel: cleanStr(c.Nombre_asignatura),
+        Sede: cleanStr(c.Nombre_sede_jornada),
+        Docente: cleanStr(c.Nombre_docente),
+        CodigoDocente: cleanStr(c.Codigo_docente),
+        Periodo: cleanStr(c.Nombre_periodo),
+        FechaInicio: cleanStr(c.Fecha_inicio).slice(0, 10),
+        FechaFin: cleanStr(c.Fecha_fin).slice(0, 10),
+        Estado: cleanStr(c.Estado),
+        cupo,
+        matriculados,
+        ocupacion,
+        disponibles: Math.max(0, cupo - matriculados),
+        modality,
+        city,
+      };
+    });
+
+    // ─── Alerts — two buckets: overbooked and underbooked ───
+    const overbooked = enriched.filter(
+      (e) => e.ocupacion !== null && e.ocupacion >= this.OVERBOOKED_PERCENT,
+    );
+    const underbooked = enriched.filter(
+      (e) => e.matriculados > 0 && e.matriculados < this.UNDERBOOKED_ABSOLUTE,
+    );
+    const empty = enriched.filter((e) => e.matriculados === 0);
+
+    // ─── Distributions ───
+    const byModality = groupCount(enriched, (e) => e.modality);
+    const byCity = groupCount(enriched, (e) => e.city);
+    const bySede = groupCount(enriched, (e) => e.Sede || 'Sin sede');
+    const byNivel = groupCount(enriched, (e) => e.Nivel || 'Sin nivel');
+
+    // ─── Teachers: one row per Codigo_docente, with course count + total seats ───
+    const teacherMap = new Map<string, {
+      codigo: string;
+      nombre: string;
+      cursos: number;
+      estudiantes: number;
+      cupoTotal: number;
+    }>();
+    for (const e of enriched) {
+      if (!e.CodigoDocente) continue;
+      const row = teacherMap.get(e.CodigoDocente) ?? {
+        codigo: e.CodigoDocente,
+        nombre: e.Docente || '—',
+        cursos: 0,
+        estudiantes: 0,
+        cupoTotal: 0,
+      };
+      row.cursos += 1;
+      row.estudiantes += e.matriculados;
+      row.cupoTotal += e.cupo;
+      teacherMap.set(e.CodigoDocente, row);
+    }
+    const teachersByLoad = [...teacherMap.values()].sort(
+      (a, b) => b.cursos - a.cursos || b.estudiantes - a.estudiantes,
+    );
+
+    // ─── Aggregate numbers for the KPI strip ───
+    const totalCupo = enriched.reduce((a, e) => a + e.cupo, 0);
+    const totalMatriculados = enriched.reduce((a, e) => a + e.matriculados, 0);
+    const ocupacionMedia = totalCupo > 0
+      ? Math.round((totalMatriculados / totalCupo) * 100)
+      : null;
+
+    return {
+      generatedAt: new Date().toISOString(),
+      partial: Object.keys(errors).length > 0,
+      errors,
+      degraded,
+      summary: {
+        totalCursos: enriched.length,
+        totalCupo,
+        totalMatriculados,
+        ocupacionMedia,
+        overbookedCount: overbooked.length,
+        underbookedCount: underbooked.length,
+        emptyCount: empty.length,
+        docentesActivos: teacherMap.size,
+      },
+      distributions: {
+        byModality,
+        byCity,
+        bySede,
+        byNivel,
+      },
+      alerts: {
+        overbooked: overbooked
+          .slice()
+          .sort((a, b) => (b.ocupacion ?? 0) - (a.ocupacion ?? 0))
+          .slice(0, 20),
+        underbooked: underbooked
+          .slice()
+          .sort((a, b) => a.matriculados - b.matriculados)
+          .slice(0, 20),
+        empty: empty.slice(0, 20),
+      },
+      courses: enriched
+        .slice()
+        .sort((a, b) => (b.ocupacion ?? 0) - (a.ocupacion ?? 0)),
+      teachers: teachersByLoad.slice(0, 30),
+      // Surface gaps explicitly — the UI shows these as footer notes so the
+      // operator knows *why* the numbers might be incomplete.
+      notes: {
+        particulares: 'Aulas particulares no están cadastradas en Q10 — no contabilizadas.',
+        cancelamentos: 'Cancelaciones no son registradas en Q10 — el churn se calcula por ausencia entre períodos.',
+      },
+    };
+  }
+}

--- a/src/q10/q10.module.ts
+++ b/src/q10/q10.module.ts
@@ -5,6 +5,7 @@ import { AcademicService } from './dashboard/academic.service';
 import { CommercialService } from './dashboard/commercial.service';
 import { CurrencyService } from './dashboard/currency.service';
 import { FinancialService } from './dashboard/financial.service';
+import { TurmasService } from './dashboard/turmas.service';
 import { DashboardController } from './dashboard.controller';
 import { DashboardService } from './dashboard.service';
 import { EnrollmentService } from './enrollment.service';
@@ -27,6 +28,7 @@ import { TrackingService } from './tracking.service';
     FinancialService,
     CommercialService,
     CurrencyService,
+    TurmasService,
   ],
   exports: [Q10ClientService, TrackingService],
 })

--- a/src/q10/q10.module.ts
+++ b/src/q10/q10.module.ts
@@ -5,6 +5,7 @@ import { AcademicService } from './dashboard/academic.service';
 import { CommercialService } from './dashboard/commercial.service';
 import { CurrencyService } from './dashboard/currency.service';
 import { FinancialService } from './dashboard/financial.service';
+import { RiskAnalysisService } from './dashboard/risk-analysis.service';
 import { TurmasService } from './dashboard/turmas.service';
 import { DashboardController } from './dashboard.controller';
 import { DashboardService } from './dashboard.service';
@@ -25,6 +26,7 @@ import { TrackingService } from './tracking.service';
     EnrollmentService,
     DashboardService,
     AcademicService,
+    RiskAnalysisService,
     FinancialService,
     CommercialService,
     CurrencyService,

--- a/test/academic.service.spec.ts
+++ b/test/academic.service.spec.ts
@@ -1,0 +1,352 @@
+import { Test } from '@nestjs/testing';
+import { AcademicService } from '../src/q10/dashboard/academic.service';
+import { Q10ClientService } from '../src/q10/q10-client.service';
+
+const DAY = 24 * 60 * 60 * 1000;
+
+const makeQ10 = (responses: Record<string, any[] | (() => any[])>) =>
+  ({
+    getAll: jest.fn(async (path: string) => {
+      const v = responses[path];
+      if (typeof v === 'function') return v();
+      return v ?? [];
+    }),
+  } as any);
+
+const now = Date.now();
+const activePeriod = {
+  Consecutivo: 'P-NOW',
+  Nombre: 'Período Activo',
+  Estado: 'Activo',
+  Fecha_inicio: new Date(now - 10 * DAY).toISOString(),
+  Fecha_fin: new Date(now + 30 * DAY).toISOString(),
+};
+
+/** Build an ISO YYYY-MM-DD for N months ago. 30.44 days/month matches
+ *  the helpers `monthsBetween` conversion factor. */
+const monthsAgoIso = (months: number): string => {
+  const ms = months * 30.44 * DAY;
+  return new Date(now - ms).toISOString().slice(0, 10);
+};
+
+/** Build the fixture set for one student with the given evaluation row. */
+const buildFixtures = (
+  students: any[],
+  evaluaciones: any[],
+) => ({
+  '/periodos': [activePeriod],
+  '/docentes': [] as any[],
+  '/estudiantes': students,
+  '/evaluaciones': evaluaciones,
+});
+
+const buildService = async (responses: Record<string, any[] | (() => any[])>) => {
+  const q10 = makeQ10(responses);
+  const moduleRef = await Test.createTestingModule({
+    providers: [
+      AcademicService,
+      { provide: Q10ClientService, useValue: q10 },
+    ],
+  }).compile();
+  return moduleRef.get(AcademicService);
+};
+
+describe('AcademicService — riskFlags', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('does not flag a student with clean metrics (happy path)', async () => {
+    const students = [
+      {
+        Codigo_estudiante: 'S-CLEAN',
+        Primer_nombre: 'Ana',
+        Primer_apellido: 'Silva',
+        Nombre_nivel: 'A2',
+        // 5 months in Regular → expected index 1 (A2). Current A2 → on track.
+        Fecha_matricula: monthsAgoIso(5),
+      },
+    ];
+    const evaluaciones = [
+      {
+        Codigo_estudiante: 'S-CLEAN',
+        Nombre_curso: '01 R - Recife',
+        Porcentaje_inasistencia: 5,
+        Promedio_evaluacion: 0.85,
+        Porcentaje_evaluado: 80,
+      },
+    ];
+
+    const svc = await buildService(buildFixtures(students, evaluaciones));
+    const result = await svc.academic();
+
+    expect(result.riskFlags).toHaveLength(0);
+    expect(result.summary.atRiskCount).toBe(0);
+  });
+
+  it('flags a student with inasistencia above 20% ("35% faltas")', async () => {
+    const students = [
+      {
+        Codigo_estudiante: 'S-ABS',
+        Primer_nombre: 'Bruno',
+        Primer_apellido: 'Costa',
+        Nombre_nivel: 'A2',
+        Fecha_matricula: monthsAgoIso(5),
+      },
+    ];
+    const evaluaciones = [
+      {
+        Codigo_estudiante: 'S-ABS',
+        Nombre_curso: '01 R - Recife',
+        Porcentaje_inasistencia: 35,
+        Promedio_evaluacion: 0.85,
+        Porcentaje_evaluado: 80,
+      },
+    ];
+
+    const svc = await buildService(buildFixtures(students, evaluaciones));
+    const result = await svc.academic();
+
+    expect(result.riskFlags).toHaveLength(1);
+    expect(result.riskFlags[0].flags).toEqual(
+      expect.arrayContaining([expect.stringContaining('35% faltas')]),
+    );
+  });
+
+  it('flags a student with promedio below threshold ("nota 0.40")', async () => {
+    const students = [
+      {
+        Codigo_estudiante: 'S-LOW',
+        Primer_nombre: 'Carla',
+        Primer_apellido: 'Dias',
+        Nombre_nivel: 'A2',
+        Fecha_matricula: monthsAgoIso(5),
+      },
+    ];
+    const evaluaciones = [
+      {
+        Codigo_estudiante: 'S-LOW',
+        Nombre_curso: '01 R - Recife',
+        Porcentaje_inasistencia: 5,
+        Promedio_evaluacion: 0.4,
+        Porcentaje_evaluado: 80,
+      },
+    ];
+
+    const svc = await buildService(buildFixtures(students, evaluaciones));
+    const result = await svc.academic();
+
+    expect(result.riskFlags).toHaveLength(1);
+    expect(result.riskFlags[0].flags).toEqual(
+      expect.arrayContaining([expect.stringContaining('nota 0.40')]),
+    );
+  });
+
+  it('does NOT flag a student with promedio = 0 as a low-grade case', async () => {
+    const students = [
+      {
+        Codigo_estudiante: 'S-NODATA',
+        Primer_nombre: 'Diego',
+        Primer_apellido: 'Esposito',
+        Nombre_nivel: 'A2',
+        Fecha_matricula: monthsAgoIso(5),
+      },
+    ];
+    const evaluaciones = [
+      {
+        Codigo_estudiante: 'S-NODATA',
+        Nombre_curso: '01 R - Recife',
+        Porcentaje_inasistencia: 5,
+        Promedio_evaluacion: 0,
+        Porcentaje_evaluado: 80,
+      },
+    ];
+
+    const svc = await buildService(buildFixtures(students, evaluaciones));
+    const result = await svc.academic();
+
+    // No flags at all — promedio=0 means "no data", inasistencia is fine,
+    // and A2 at 5 months Regular is on track.
+    expect(result.riskFlags).toHaveLength(0);
+    expect(result.summary.atRiskCount).toBe(0);
+  });
+
+  it('flags a stalled Regular student (6 months, still A1)', async () => {
+    const students = [
+      {
+        Codigo_estudiante: 'S-STALL',
+        Primer_nombre: 'Elena',
+        Primer_apellido: 'Ferreira',
+        Nombre_nivel: 'A1',
+        // 6 months / 3 months-per-level Regular = expected index 2 (B1)
+        Fecha_matricula: monthsAgoIso(6),
+      },
+    ];
+    const evaluaciones = [
+      {
+        Codigo_estudiante: 'S-STALL',
+        Nombre_curso: '01 R - Recife',
+        Porcentaje_inasistencia: 5,
+        Promedio_evaluacion: 0.85,
+        Porcentaje_evaluado: 80,
+      },
+    ];
+
+    const svc = await buildService(buildFixtures(students, evaluaciones));
+    const result = await svc.academic();
+
+    expect(result.riskFlags).toHaveLength(1);
+    expect(result.riskFlags[0].flags).toEqual(
+      expect.arrayContaining([expect.stringContaining('nivel(es) atrás')]),
+    );
+  });
+
+  it('does NOT add a stalled-progression flag for Desconocida modality', async () => {
+    const students = [
+      {
+        Codigo_estudiante: 'S-UNK',
+        Primer_nombre: 'Fabio',
+        Primer_apellido: 'Gomes',
+        Nombre_nivel: 'A1',
+        Fecha_matricula: monthsAgoIso(12),
+      },
+    ];
+    // Unrecognised course string → classifyModality returns 'Desconocida'.
+    const evaluaciones = [
+      {
+        Codigo_estudiante: 'S-UNK',
+        Nombre_curso: 'Curso raro sin patrón',
+        Porcentaje_inasistencia: 5,
+        Promedio_evaluacion: 0.85,
+        Porcentaje_evaluado: 80,
+      },
+    ];
+
+    const svc = await buildService(buildFixtures(students, evaluaciones));
+    const result = await svc.academic();
+
+    // No flags — stalled branch is gated on modality !== 'Desconocida'.
+    expect(result.riskFlags).toHaveLength(0);
+    expect(result.summary.atRiskCount).toBe(0);
+  });
+
+  it('sorts riskFlags by flag count desc, tie-broken by inasistencia desc', async () => {
+    const students = [
+      {
+        // 1 flag, high inasistencia
+        Codigo_estudiante: 'S-ONE-HIGH',
+        Primer_nombre: 'Gabriela',
+        Primer_apellido: 'Hernández',
+        Nombre_nivel: 'A2',
+        Fecha_matricula: monthsAgoIso(5),
+      },
+      {
+        // 3 flags — should be first
+        Codigo_estudiante: 'S-THREE',
+        Primer_nombre: 'Hugo',
+        Primer_apellido: 'Iriarte',
+        Nombre_nivel: 'A1',
+        Fecha_matricula: monthsAgoIso(6),
+      },
+      {
+        // 1 flag, lower inasistencia — breaks tie against S-ONE-HIGH
+        Codigo_estudiante: 'S-ONE-LOW',
+        Primer_nombre: 'Irene',
+        Primer_apellido: 'Juárez',
+        Nombre_nivel: 'A2',
+        Fecha_matricula: monthsAgoIso(5),
+      },
+    ];
+    const evaluaciones = [
+      {
+        Codigo_estudiante: 'S-ONE-HIGH',
+        Nombre_curso: '01 R - Recife',
+        Porcentaje_inasistencia: 40,
+        Promedio_evaluacion: 0.85,
+        Porcentaje_evaluado: 80,
+      },
+      {
+        // 3 flags: faltas + low grade + stalled
+        Codigo_estudiante: 'S-THREE',
+        Nombre_curso: '01 R - Recife',
+        Porcentaje_inasistencia: 25,
+        Promedio_evaluacion: 0.3,
+        Porcentaje_evaluado: 80,
+      },
+      {
+        Codigo_estudiante: 'S-ONE-LOW',
+        Nombre_curso: '01 R - Recife',
+        Porcentaje_inasistencia: 22,
+        Promedio_evaluacion: 0.85,
+        Porcentaje_evaluado: 80,
+      },
+    ];
+
+    const svc = await buildService(buildFixtures(students, evaluaciones));
+    const result = await svc.academic();
+
+    expect(result.riskFlags).toHaveLength(3);
+    expect(result.riskFlags[0].Codigo).toBe('S-THREE');
+    expect(result.riskFlags[0].flags.length).toBe(3);
+    expect(result.riskFlags[1].Codigo).toBe('S-ONE-HIGH');
+    expect(result.riskFlags[2].Codigo).toBe('S-ONE-LOW');
+    expect(result.riskFlags[1].inasistencia).toBeGreaterThan(
+      result.riskFlags[2].inasistencia,
+    );
+  });
+
+  it('summary.atRiskCount matches riskFlags.length', async () => {
+    const students = [
+      {
+        Codigo_estudiante: 'S-FLAGGED-1',
+        Primer_nombre: 'Julia',
+        Primer_apellido: 'Klein',
+        Nombre_nivel: 'A2',
+        Fecha_matricula: monthsAgoIso(5),
+      },
+      {
+        Codigo_estudiante: 'S-FLAGGED-2',
+        Primer_nombre: 'Kevin',
+        Primer_apellido: 'Lopes',
+        Nombre_nivel: 'A2',
+        Fecha_matricula: monthsAgoIso(5),
+      },
+      {
+        Codigo_estudiante: 'S-CLEAN-2',
+        Primer_nombre: 'Laura',
+        Primer_apellido: 'Matos',
+        Nombre_nivel: 'A2',
+        Fecha_matricula: monthsAgoIso(5),
+      },
+    ];
+    const evaluaciones = [
+      {
+        Codigo_estudiante: 'S-FLAGGED-1',
+        Nombre_curso: '01 R - Recife',
+        Porcentaje_inasistencia: 50,
+        Promedio_evaluacion: 0.85,
+        Porcentaje_evaluado: 80,
+      },
+      {
+        Codigo_estudiante: 'S-FLAGGED-2',
+        Nombre_curso: '01 R - Recife',
+        Porcentaje_inasistencia: 5,
+        Promedio_evaluacion: 0.35,
+        Porcentaje_evaluado: 80,
+      },
+      {
+        Codigo_estudiante: 'S-CLEAN-2',
+        Nombre_curso: '01 R - Recife',
+        Porcentaje_inasistencia: 5,
+        Promedio_evaluacion: 0.85,
+        Porcentaje_evaluado: 80,
+      },
+    ];
+
+    const svc = await buildService(buildFixtures(students, evaluaciones));
+    const result = await svc.academic();
+
+    expect(result.summary.atRiskCount).toBe(result.riskFlags.length);
+    expect(result.summary.atRiskCount).toBe(2);
+  });
+});

--- a/test/academic.service.spec.ts
+++ b/test/academic.service.spec.ts
@@ -1,5 +1,6 @@
 import { Test } from '@nestjs/testing';
 import { AcademicService } from '../src/q10/dashboard/academic.service';
+import { RiskAnalysisService } from '../src/q10/dashboard/risk-analysis.service';
 import { Q10ClientService } from '../src/q10/q10-client.service';
 
 const DAY = 24 * 60 * 60 * 1000;
@@ -45,6 +46,7 @@ const buildService = async (responses: Record<string, any[] | (() => any[])>) =>
   const moduleRef = await Test.createTestingModule({
     providers: [
       AcademicService,
+      RiskAnalysisService,
       { provide: Q10ClientService, useValue: q10 },
     ],
   }).compile();

--- a/test/dashboard-guards.e2e-spec.ts
+++ b/test/dashboard-guards.e2e-spec.ts
@@ -1,0 +1,69 @@
+import { INestApplication } from '@nestjs/common';
+import request = require('supertest');
+import { createTestApp, loginAsAdmin } from './helpers/app';
+
+/**
+ * Regression guard for the admin dashboard: every route under
+ * /api/dashboard/* must require a valid session cookie, including the
+ * POST /refresh action which evicts the Q10 cache. Without this suite, a
+ * controller-level `@UseGuards(JwtAuthGuard)` could be accidentally
+ * dropped in a refactor and nothing would fail — see PR #11 review.
+ */
+describe('Dashboard routes — all require auth (#refresh-guard)', () => {
+  let app: INestApplication;
+  let adminCookie: string;
+
+  beforeAll(async () => {
+    app = await createTestApp();
+    adminCookie = await loginAsAdmin(app);
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  describe('without cookie → 401', () => {
+    it.each([
+      ['GET',  '/api/dashboard/overview'],
+      ['GET',  '/api/dashboard/academic'],
+      ['GET',  '/api/dashboard/financial'],
+      ['GET',  '/api/dashboard/commercial'],
+      ['GET',  '/api/dashboard/turmas'],
+      ['GET',  '/api/dashboard/currency-rates'],
+      ['POST', '/api/dashboard/refresh'],
+    ])('%s %s → 401', async (method, path) => {
+      const req = request(app.getHttpServer());
+      const call = method === 'POST' ? req.post(path) : req.get(path);
+      await call.expect(401);
+    });
+  });
+
+  describe('with admin cookie → 200', () => {
+    it('POST /api/dashboard/refresh with admin cookie → 201', async () => {
+      // NestJS defaults POST to 201 Created (no `@HttpCode(200)` on the
+      // handler). The important assertion is "guard lets us through".
+      const resp = await request(app.getHttpServer())
+        .post('/api/dashboard/refresh')
+        .set('Cookie', adminCookie)
+        .expect(201);
+      expect(resp.body).toEqual(
+        expect.objectContaining({
+          success: true,
+          clearedAt: expect.any(String),
+        }),
+      );
+    });
+
+    it('GET /api/dashboard/currency-rates with admin cookie → 200', async () => {
+      const resp = await request(app.getHttpServer())
+        .get('/api/dashboard/currency-rates')
+        .set('Cookie', adminCookie)
+        .expect(200);
+      expect(resp.body).toEqual(
+        expect.objectContaining({
+          rates: expect.any(Object),
+        }),
+      );
+    });
+  });
+});

--- a/test/financial-segmentation.spec.ts
+++ b/test/financial-segmentation.spec.ts
@@ -1,0 +1,107 @@
+import { FinancialService } from '../src/q10/dashboard/financial.service';
+
+const makeQ10 = (responses: Record<string, any[] | (() => any[])>) =>
+  ({
+    getAll: jest.fn(async (path: string) => {
+      const v = responses[path];
+      if (typeof v === 'function') return v();
+      return v ?? [];
+    }),
+  } as any);
+
+describe('FinancialService — modality-segmented revenue', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  const pagos = [
+    // Regular payments
+    {
+      Codigo_persona: 'P1',
+      Nombre_producto: 'Mensualidad 14 R - Recife',
+      Valor_pagado: 100,
+      Fecha_pago: '2026-03-01',
+    },
+    {
+      Codigo_persona: 'P2',
+      Nombre_producto: 'Mensualidad 12 Regular - Panamá',
+      Valor_pagado: 150,
+      Fecha_pago: '2026-03-02',
+    },
+    // Semi Intensivo payments
+    {
+      Codigo_persona: 'P3',
+      Nombre_producto: 'Mensualidad 08 S - San José',
+      Valor_pagado: 200,
+      Fecha_pago: '2026-03-03',
+    },
+    {
+      Codigo_persona: 'P4',
+      Nombre_producto: 'Mensualidad 05 Semi Intensivo - Panamá',
+      Valor_pagado: 75,
+      Fecha_pago: '2026-03-04',
+    },
+    // Unclassified (Matrícula)
+    {
+      Codigo_persona: 'P5',
+      Nombre_producto: 'Matrícula',
+      Valor_pagado: 40,
+      Fecha_pago: '2026-03-05',
+    },
+  ];
+
+  it('sums revenue per modality and exposes all three keys in charts', async () => {
+    const q10 = makeQ10({
+      '/periodos': [],
+      '/pagos': pagos,
+    });
+    const svc = new FinancialService(q10);
+
+    const result = await svc.financial(12);
+
+    expect(result.summary.revenueRegular).toBe(250); // 100 + 150
+    expect(result.summary.revenueIntensivo).toBe(275); // 200 + 75
+    expect(result.summary.revenueUnclassified).toBe(40);
+
+    expect(result.charts.revenueByModality).toBeDefined();
+    expect(Object.keys(result.charts.revenueByModality).sort()).toEqual(
+      ['Desconocida', 'Regular', 'Semi Intensivo'].sort(),
+    );
+    expect(result.charts.revenueByModality.Regular).toBe(250);
+    expect(result.charts.revenueByModality['Semi Intensivo']).toBe(275);
+    expect(result.charts.revenueByModality.Desconocida).toBe(40);
+  });
+
+  it('honours explicit from/to ISO dates', async () => {
+    const q10 = makeQ10({
+      '/periodos': [],
+      '/pagos': pagos,
+    });
+    const svc = new FinancialService(q10);
+
+    const result = await svc.financial(12, '2026-01-01', '2026-04-01');
+    expect(result.summary.from).toBe('2026-01-01');
+    expect(result.summary.to).toBe('2026-04-01');
+  });
+
+  it('falls back to monthsBack when from is invalid or missing', async () => {
+    const q10 = makeQ10({
+      '/periodos': [],
+      '/pagos': pagos,
+    });
+    const svc = new FinancialService(q10);
+
+    // Invalid "from" — falls back to monthsBack window.
+    const result = await svc.financial(6, 'not-a-date');
+    expect(result.summary.from).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    expect(result.summary.to).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    // The rangeStart is ~6 months before `to`; ensure from < to.
+    expect(result.summary.from < result.summary.to).toBe(true);
+
+    // Missing "from" entirely — same fallback path.
+    const result2 = await svc.financial(3);
+    expect(result2.summary.from).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    expect(result2.summary.to).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    expect(result2.summary.from < result2.summary.to).toBe(true);
+  });
+});

--- a/test/helpers.spec.ts
+++ b/test/helpers.spec.ts
@@ -1,0 +1,275 @@
+import {
+  ageBucket,
+  ageFromBirthdate,
+  cefrIndex,
+  classifyModality,
+  currentlyActivePeriods,
+  expectedLevelAdvance,
+  groupCount,
+  groupSum,
+  isActivo,
+  monthsBetween,
+} from '../src/q10/dashboard/helpers';
+
+describe('classifyModality', () => {
+  it('recognises the short "R" marker as Regular', () => {
+    expect(classifyModality('14 R - Recife')).toBe('Regular');
+  });
+
+  it('recognises the short "S" marker as Semi Intensivo', () => {
+    expect(classifyModality('08 S - San José')).toBe('Semi Intensivo');
+  });
+
+  it('recognises the verbose "Regular" form', () => {
+    expect(classifyModality('12 Regular - Recife')).toBe('Regular');
+  });
+
+  it('recognises the verbose "Semi Intensivo" form', () => {
+    expect(classifyModality('05 Semi Intensivo - Panamá')).toBe('Semi Intensivo');
+  });
+
+  it('returns Desconocida for unrelated labels like "Matrícula"', () => {
+    expect(classifyModality('Matrícula')).toBe('Desconocida');
+  });
+
+  it('returns Desconocida for an empty string', () => {
+    expect(classifyModality('')).toBe('Desconocida');
+  });
+
+  it('returns Desconocida for null input', () => {
+    expect(classifyModality(null)).toBe('Desconocida');
+  });
+
+  it('is case-insensitive', () => {
+    expect(classifyModality('14 r - Recife')).toBe('Regular');
+  });
+});
+
+describe('cefrIndex', () => {
+  it('maps A1..C2 to 0..5', () => {
+    expect(cefrIndex('A1')).toBe(0);
+    expect(cefrIndex('A2')).toBe(1);
+    expect(cefrIndex('B1')).toBe(2);
+    expect(cefrIndex('B2')).toBe(3);
+    expect(cefrIndex('C1')).toBe(4);
+    expect(cefrIndex('C2')).toBe(5);
+  });
+
+  it('returns null for unknown levels', () => {
+    expect(cefrIndex('D1')).toBeNull();
+    expect(cefrIndex('')).toBeNull();
+    expect(cefrIndex(null)).toBeNull();
+  });
+
+  it('is case-insensitive', () => {
+    expect(cefrIndex('a1')).toBe(0);
+    expect(cefrIndex('b2')).toBe(3);
+  });
+});
+
+describe('expectedLevelAdvance', () => {
+  it('Regular: 7 months → 2 levels (floor(7/3))', () => {
+    expect(expectedLevelAdvance('Regular', 7)).toBe(2);
+  });
+
+  it('Semi Intensivo: 7 months → 4 levels (floor(7/1.5))', () => {
+    expect(expectedLevelAdvance('Semi Intensivo', 7)).toBe(4);
+  });
+
+  it('Desconocida: always 0', () => {
+    expect(expectedLevelAdvance('Desconocida', 12)).toBe(0);
+    expect(expectedLevelAdvance('Desconocida', 0)).toBe(0);
+  });
+
+  it('Regular with 0 months → 0', () => {
+    expect(expectedLevelAdvance('Regular', 0)).toBe(0);
+  });
+
+  it('Regular with negative months → 0', () => {
+    expect(expectedLevelAdvance('Regular', -3)).toBe(0);
+  });
+});
+
+describe('monthsBetween', () => {
+  it('computes ~3 months between 2024-01-01 and 2024-04-01', () => {
+    const v = monthsBetween('2024-01-01', '2024-04-01');
+    expect(v).not.toBeNull();
+    expect(v!).toBeGreaterThan(2.9);
+    expect(v!).toBeLessThan(3.1);
+  });
+
+  it('returns null for an unparseable "from"', () => {
+    expect(monthsBetween('invalid')).toBeNull();
+  });
+
+  it('returns null when "from" is null', () => {
+    expect(monthsBetween(null)).toBeNull();
+  });
+});
+
+describe('ageFromBirthdate', () => {
+  it('returns a reasonable age for a known past date', () => {
+    const age = ageFromBirthdate('2000-01-01');
+    expect(age).not.toBeNull();
+    expect(age!).toBeGreaterThanOrEqual(24);
+    expect(age!).toBeLessThanOrEqual(30);
+  });
+
+  it('returns null for unparseable input', () => {
+    expect(ageFromBirthdate('not-a-date')).toBeNull();
+    expect(ageFromBirthdate(null)).toBeNull();
+    expect(ageFromBirthdate(undefined)).toBeNull();
+  });
+
+  it('returns null for a future date', () => {
+    expect(ageFromBirthdate('2999-01-01')).toBeNull();
+  });
+
+  it('returns null for a ~150-year-old date', () => {
+    expect(ageFromBirthdate('1870-01-01')).toBeNull();
+  });
+});
+
+describe('ageBucket', () => {
+  it('11 → "<12"', () => {
+    expect(ageBucket(11)).toBe('<12');
+  });
+
+  it('12 → "12-17"', () => {
+    expect(ageBucket(12)).toBe('12-17');
+  });
+
+  it('17 → "12-17"', () => {
+    expect(ageBucket(17)).toBe('12-17');
+  });
+
+  it('18 → "18-24"', () => {
+    expect(ageBucket(18)).toBe('18-24');
+  });
+
+  it('24 → "18-24"', () => {
+    expect(ageBucket(24)).toBe('18-24');
+  });
+
+  it('25 → "25-34"', () => {
+    expect(ageBucket(25)).toBe('25-34');
+  });
+
+  it('50 → "50-64"', () => {
+    expect(ageBucket(50)).toBe('50-64');
+  });
+
+  it('65 → "65+"', () => {
+    expect(ageBucket(65)).toBe('65+');
+  });
+});
+
+describe('currentlyActivePeriods', () => {
+  const DAY = 24 * 60 * 60 * 1000;
+
+  it('returns only periods whose range contains today', () => {
+    const now = Date.now();
+    const periodos = [
+      {
+        Consecutivo: 'CURR',
+        Estado: 'Activo',
+        Fecha_inicio: new Date(now - 10 * DAY).toISOString(),
+        Fecha_fin: new Date(now + 30 * DAY).toISOString(),
+      },
+      {
+        Consecutivo: 'PAST',
+        Estado: 'Activo',
+        Fecha_inicio: new Date(now - 200 * DAY).toISOString(),
+        Fecha_fin: new Date(now - 100 * DAY).toISOString(),
+      },
+    ];
+
+    const result = currentlyActivePeriods(periodos);
+    expect(result).toHaveLength(1);
+    expect(result[0].Consecutivo).toBe('CURR');
+  });
+
+  it('falls back to all active when none contain today', () => {
+    const now = Date.now();
+    const periodos = [
+      {
+        Consecutivo: 'PAST1',
+        Estado: 'Activo',
+        Fecha_inicio: new Date(now - 400 * DAY).toISOString(),
+        Fecha_fin: new Date(now - 300 * DAY).toISOString(),
+      },
+      {
+        Consecutivo: 'PAST2',
+        Estado: 'Activo',
+        Fecha_inicio: new Date(now - 200 * DAY).toISOString(),
+        Fecha_fin: new Date(now - 100 * DAY).toISOString(),
+      },
+      {
+        Consecutivo: 'INACTIVE',
+        Estado: 'Inactivo',
+        Fecha_inicio: new Date(now - 50 * DAY).toISOString(),
+        Fecha_fin: new Date(now + 50 * DAY).toISOString(),
+      },
+    ];
+
+    const result = currentlyActivePeriods(periodos);
+    // Both Activo-but-past are returned; the Inactivo one is filtered out.
+    expect(result).toHaveLength(2);
+    expect(result.map((p) => p.Consecutivo).sort()).toEqual(['PAST1', 'PAST2']);
+  });
+});
+
+describe('groupCount', () => {
+  it('counts items grouped by key', () => {
+    const items = [{ m: 'A' }, { m: 'B' }, { m: 'A' }, { m: 'A' }];
+    expect(groupCount(items, (x) => x.m)).toEqual({ A: 3, B: 1 });
+  });
+
+  it('uses "Sin especificar" when the key is empty', () => {
+    const items = [{ m: '' }, { m: null }, { m: 'A' }];
+    expect(groupCount(items, (x) => x.m)).toEqual({
+      'Sin especificar': 2,
+      A: 1,
+    });
+  });
+});
+
+describe('groupSum', () => {
+  it('sums a numeric field grouped by key', () => {
+    const items = [
+      { k: 'A', v: 10 },
+      { k: 'B', v: 5 },
+      { k: 'A', v: 2 },
+    ];
+    expect(groupSum(items, (x) => x.k, 'v')).toEqual({ A: 12, B: 5 });
+  });
+
+  it('uses "Sin especificar" fallback for missing keys', () => {
+    const items = [
+      { k: '', v: 7 },
+      { k: 'A', v: 3 },
+    ];
+    expect(groupSum(items, (x) => x.k, 'v')).toEqual({
+      'Sin especificar': 7,
+      A: 3,
+    });
+  });
+});
+
+describe('isActivo', () => {
+  it('recognises truthy variants', () => {
+    expect(isActivo(true)).toBe(true);
+    expect(isActivo('true')).toBe(true);
+    expect(isActivo('Activo')).toBe(true);
+    expect(isActivo('active')).toBe(true);
+    expect(isActivo('1')).toBe(true);
+  });
+
+  it('rejects falsy/inactive variants', () => {
+    expect(isActivo('inactivo')).toBe(false);
+    expect(isActivo('false')).toBe(false);
+    expect(isActivo(null)).toBe(false);
+    expect(isActivo(undefined)).toBe(false);
+    expect(isActivo('')).toBe(false);
+  });
+});

--- a/test/turmas.spec.ts
+++ b/test/turmas.spec.ts
@@ -1,0 +1,205 @@
+import { TurmasService } from '../src/q10/dashboard/turmas.service';
+
+const DAY = 24 * 60 * 60 * 1000;
+
+const makeQ10 = (responses: Record<string, any[] | (() => any[])>) =>
+  ({
+    getAll: jest.fn(async (path: string) => {
+      const v = responses[path];
+      if (typeof v === 'function') return v();
+      return v ?? [];
+    }),
+  } as any);
+
+const now = Date.now();
+const activePeriod = {
+  Consecutivo: 'P-NOW',
+  Estado: 'Activo',
+  Fecha_inicio: new Date(now - 10 * DAY).toISOString(),
+  Fecha_fin: new Date(now + 30 * DAY).toISOString(),
+};
+const pastPeriod = {
+  Consecutivo: 'P-PAST',
+  Estado: 'Activo',
+  Fecha_inicio: new Date(now - 400 * DAY).toISOString(),
+  Fecha_fin: new Date(now - 300 * DAY).toISOString(),
+};
+
+describe('TurmasService', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('happy path: summary, distributions and alerts reflect active courses', async () => {
+    // 5 courses: 3 in active period (1 regular full, 1 regular empty, 1 semi
+    // underbooked), 1 in past period (should be ignored), 1 closed.
+    const cursos = [
+      {
+        Codigo: 'C1',
+        Consecutivo: 'C1',
+        Consecutivo_periodo: 'P-NOW',
+        Nombre: '14 R - Recife',
+        Estado: 'Activo',
+        Cupo_maximo: 10,
+        Cantidad_estudiantes_matriculados: 10, // 100% → overbooked
+        Codigo_docente: 'T1',
+        Nombre_docente: 'Teacher One',
+      },
+      {
+        Codigo: 'C2',
+        Consecutivo: 'C2',
+        Consecutivo_periodo: 'P-NOW',
+        Nombre: '08 S - San José',
+        Estado: 'Activo',
+        Cupo_maximo: 10,
+        Cantidad_estudiantes_matriculados: 3, // 30% → underbooked (0<3<5)
+        Codigo_docente: 'T2',
+        Nombre_docente: 'Teacher Two',
+      },
+      {
+        Codigo: 'C3',
+        Consecutivo: 'C3',
+        Consecutivo_periodo: 'P-NOW',
+        Nombre: '15 R - Panamá',
+        Estado: 'Activo',
+        Cupo_maximo: 10,
+        Cantidad_estudiantes_matriculados: 0, // empty
+        Codigo_docente: 'T1',
+        Nombre_docente: 'Teacher One',
+      },
+      {
+        // Belongs to past period — filtered out.
+        Codigo: 'C-OLD',
+        Consecutivo: 'C-OLD',
+        Consecutivo_periodo: 'P-PAST',
+        Nombre: '01 R - Recife',
+        Estado: 'Activo',
+        Cupo_maximo: 10,
+        Cantidad_estudiantes_matriculados: 9,
+        Codigo_docente: 'T3',
+        Nombre_docente: 'Teacher Three',
+      },
+      {
+        // Estado != Activo — filtered out.
+        Codigo: 'C-CLOSED',
+        Consecutivo: 'C-CLOSED',
+        Consecutivo_periodo: 'P-NOW',
+        Nombre: '02 R - Recife',
+        Estado: 'Cerrado',
+        Cupo_maximo: 10,
+        Cantidad_estudiantes_matriculados: 7,
+        Codigo_docente: 'T4',
+        Nombre_docente: 'Teacher Four',
+      },
+    ];
+
+    const q10 = makeQ10({
+      '/periodos': [activePeriod, pastPeriod],
+      '/cursos': cursos,
+    });
+    const svc = new TurmasService(q10);
+
+    const result = await svc.turmas();
+
+    expect(result.summary.totalCursos).toBe(3);
+    // 13 matriculated / 30 total cupo = 43%
+    expect(result.summary.ocupacionMedia).toBe(43);
+    expect(result.summary.overbookedCount).toBe(1);
+    expect(result.summary.underbookedCount).toBe(1);
+    expect(result.summary.emptyCount).toBe(1);
+
+    expect(result.distributions.byModality['Regular']).toBe(2);
+    expect(result.distributions.byModality['Semi Intensivo']).toBe(1);
+
+    // overbooked sorted desc by ocupacion
+    expect(result.alerts.overbooked).toHaveLength(1);
+    expect(result.alerts.overbooked[0].Codigo).toBe('C1');
+
+    // underbooked sorted asc by matriculados
+    expect(result.alerts.underbooked).toHaveLength(1);
+    expect(result.alerts.underbooked[0].Codigo).toBe('C2');
+
+    expect(result.partial).toBe(false);
+  });
+
+  it('falls through period filter when /periodos returns empty', async () => {
+    const cursos = [
+      {
+        Codigo: 'X1',
+        Consecutivo: 'X1',
+        Consecutivo_periodo: 'WHATEVER',
+        Nombre: '99 R - NoWhere',
+        Estado: 'Activo',
+        Cupo_maximo: 10,
+        Cantidad_estudiantes_matriculados: 5,
+      },
+    ];
+    const q10 = makeQ10({ '/periodos': [], '/cursos': cursos });
+    const svc = new TurmasService(q10);
+
+    const result = await svc.turmas();
+    expect(result.summary.totalCursos).toBe(1);
+  });
+
+  it('populates errors.courses and marks partial when /cursos throws', async () => {
+    const q10 = makeQ10({
+      '/periodos': [activePeriod],
+      '/cursos': () => {
+        throw new Error('boom');
+      },
+    });
+    const svc = new TurmasService(q10);
+
+    const result = await svc.turmas();
+    expect(result.errors.courses).toMatch(/boom/);
+    expect(result.summary.totalCursos).toBe(0);
+    expect(result.partial).toBe(true);
+  });
+
+  it('teacher aggregation rolls up by Codigo_docente', async () => {
+    const cursos = [
+      {
+        Codigo: 'A',
+        Consecutivo_periodo: 'P-NOW',
+        Nombre: '01 R - City',
+        Estado: 'Activo',
+        Cupo_maximo: 10,
+        Cantidad_estudiantes_matriculados: 4,
+        Codigo_docente: 'DOC-99',
+        Nombre_docente: 'Ana',
+      },
+      {
+        Codigo: 'B',
+        Consecutivo_periodo: 'P-NOW',
+        Nombre: '02 R - City',
+        Estado: 'Activo',
+        Cupo_maximo: 10,
+        Cantidad_estudiantes_matriculados: 6,
+        Codigo_docente: 'DOC-99',
+        Nombre_docente: 'Ana',
+      },
+      {
+        Codigo: 'C',
+        Consecutivo_periodo: 'P-NOW',
+        Nombre: '03 R - City',
+        Estado: 'Activo',
+        Cupo_maximo: 10,
+        Cantidad_estudiantes_matriculados: 2,
+        Codigo_docente: 'DOC-99',
+        Nombre_docente: 'Ana',
+      },
+    ];
+    const q10 = makeQ10({
+      '/periodos': [activePeriod],
+      '/cursos': cursos,
+    });
+    const svc = new TurmasService(q10);
+
+    const result = await svc.turmas();
+    expect(result.teachers).toHaveLength(1);
+    const ana = result.teachers[0];
+    expect(ana.codigo).toBe('DOC-99');
+    expect(ana.cursos).toBe(3);
+    expect(ana.estudiantes).toBe(12);
+  });
+});


### PR DESCRIPTION
## Resumen

PR grande que consolida três pedidos do operador em uma única entrega:

1. **Nova aba Turmas** — visão de ocupação por curso, alertas operacionais, distribuição e ranking de docentes.
2. **Redesign da aba Acadêmico** — charts de modalidade/cidade, CEFR segmentado por modalidade, tabela de alunos em risco.
3. **Date picker + responsivo + des-emojificação** — presets de data (Hoy / Últimos 7 / Este mes / …), drawer mobile abaixo de 720px, sprite SVG inline substituindo todos os emojis.

`121 testes passando · typecheck limpo.`

---

## Mudanças

### Backend
- **`GET /api/dashboard/turmas`** (novo) — `TurmasService` agrega `/cursos` + `/periodos`, classifica modalidade via regex no `Nombre`, expõe KPIs (ocupação média, llenos, sem alunos, docentes ativos), distribuições, três buckets de alertas (`overbooked ≥90%`, `underbooked <5`, `empty`), lista de cursos ordenada por ocupação e ranking de docentes por carga.
- **Fix crítico de filtro** — `/cursos` devolve `Estado="Abierto"/"Cerrado"/"Finalizado"`, mas `isActivo` do helpers só aceita `"Activo"/"Active"`. `TurmasService` tem agora um `OPEN_COURSE_STATES` local que inclui `"abierto"` — sem isso, 100% dos cursos abertos seriam filtrados em produção.
- **`GET /api/dashboard/overview`** agora aceita `?from=YYYY-MM-DD&to=YYYY-MM-DD` além do `range` numérico; `DashboardService.overview` honra `from/to` e calcula `effectiveDays` a partir da janela real.
- **`GET /api/dashboard/financial`** idem: aceita `from/to`; `FinancialService` segmenta receita por modalidade via `classifyModality(Nombre_producto)` → nova chave `charts.revenueByModality` + `summary.revenueRegular/revenueIntensivo/revenueUnclassified`. Fix de off-by-one: quando `from` não é passado, `windowMonths` mantém `monthsBack` verbatim (teste e2e assertava 6 buckets para `months=6`).
- **`AcademicService`** — adicionou `riskFlags` (3 sinais: faltas ≥20%, nota <0.6, nível atrás do esperado), `progression.distributionRegular/distributionIntensivo`, `distributions.byModality/byCity`. Usa `/evaluaciones` como proxy de faltas (o tenant tem `/inasistencias` vazio).
- `validateIsoDate` no controller rejeita qualquer coisa que não seja `^\d{4}-\d{2}-\d{2}$` antes de repassar ao Q10.

### Frontend
- **`index.html`** — sprite SVG inline com 10 ícones (`icon-overview/academic/financial/commercial/turmas/refresh/alert/calendar/logout/menu/close`) substituindo todos os emojis. Nova estrutura da aba Academic (4 charts + riskTable) e Turmas (KPIs + 2 charts + 3 alert blocks + courses table + teachers table + notes card). Mobile menu button (`#menuBtn`) e drawer (`#headerActions`).
- **`dashboard.css`** — media queries em 960/720/440px, variantes `.occupancy__bar` / `.occupancy__fill--danger/warning/success`, `.alert-block`/`.alert-item`/`.alert-grid`, `.card--notes`, drawer mobile colapsável.
- **`dashboard.js`** (1032 linhas, reescrito) — date picker logic (presets → `from/to` em `URLSearchParams`; só Overview + Financial consomem), drawer toggle via `.open` class, loader da aba Turmas com banda colorida na coluna de ocupação, render separado de CEFR por modalidade respeitando `levelsOrder`, zero emojis nas strings de erro (`Error: …` em vez de `⚠ …`).

### Testes novos
- `test/helpers.spec.ts` — 28 casos cobrindo `classifyModality`, `cefrIndex`, `expectedLevelAdvance`, `monthsBetween`, `ageFromBirthdate`, `ageBucket`, `currentlyActivePeriods`, `groupCount`, `groupSum`, `isActivo`.
- `test/turmas.spec.ts` — happy path, fallback sem períodos, `/cursos` falhando (partial response), agregação de docentes.
- `test/financial-segmentation.spec.ts` — segmentação de modalidade e roteamento de `from/to`.

---

## Aulas particulares

Confirmado com o operador: aulas particulares ainda **não estão cadastradas no Q10**. O sistema está pronto — assim que forem inseridas, aparecerão automaticamente via `/cursos` com `modality = "Desconocida"`. Não implementei UI dedicada porque o footer de notes já sinaliza a lacuna:

> _"Aulas particulares no están cadastradas en Q10 — no contabilizadas."_

---

## Para o Q10 — atualizações urgentes sugeridas

Conforme pedido ("vamos marcar na q10 me passa o que você precisa que seja atualizado"), este é o contrato que o dashboard espera e que **hoje não está populado / é inconsistente**:

### Alta prioridade (quebra KPIs do painel)

1. **Cadastrar aulas particulares em `/cursos`** — hoje o endpoint retorna só turmas. Particulares não contabilizam matrículas nem receita. Sugestão: um `Nombre_curso` tipo `"P - {Aluno} - {Cidade}"` que nosso regex já classifica como `Desconocida` e que rapidamente podemos reclassificar para `"Particular"`.

2. **Preencher `Condicion_matricula`** em `/estudiantes` — hoje é `null` em 100% dos registros de P1 (só P2+ tem valor). Usamos para distinguir novo vs. renovado, então os KPIs "Nuevos este período" ficam subestimados.

3. **Padronizar `Estado` em `/cursos`** — usa `"Abierto"/"Cerrado"/"Finalizado"`, mas o resto da API (`/periodos`, `/estudiantes`) usa `"Activo"/"Inactivo"`. Tivemos que manter dois dicionários no backend. Pedir padronização.

4. **Popular `/inasistencias`** — hoje retorna array vazio. Caímos num fallback usando `/evaluaciones.Porcentaje_inasistencia`, mas isso só cobre quem tem avaliação. Alunos novos (sem nota ainda) não aparecem em "Alumnos en riesgo".

5. **Expor `Fecha_vencimiento` em `/pagosPendientes`** — hoje só vem `Consecutivo_periodo`. Sem a data real não conseguimos mostrar "X dias vencido" nem calcular aging (0-30, 31-60, 61-90, >90).

### Média prioridade

6. **Habilitar `/estadocuentaestudiantes`** — este tenant rejeita com `"no aplica al modelo financiero correspondiente"`. Hoje reconciliamos manualmente `/pagos.Codigo_persona` × `/estudiantes.Codigo_estudiante`.

7. **Cadastrar `Email` / `Celular` dos docentes em `/docentes`** — muitos estão em branco; a tabela de docentes do Academic fica com colunas vazias.

8. **Validar que `/oportunidades.Estado_negocio` cubra todos os estágios do funil** — hoje temos `"Ganada"`, `"Presentación"`, `"Perdida"`, mas faltam estágios intermediários pelo uso real que o operador faz do CRM. O `conversionRate` está sendo marcado como `degraded` por subutilização do CRM.

### Baixa prioridade (qualidade de vida)

9. **Uniformizar `Nombre_producto`** — a classificação regex `/\s(R|Regular|S|Semi\s*Intensivo)\s*-/i` funciona bem mas quebraria se o padrão mudasse. Sugerir um campo `Modalidad` dedicado no produto.

10. **`Fecha_pago` consistente** — alguns registros vêm com timestamp, outros só com data. O backend lida, mas `Intl.DateTimeFormat` precisa de normalização antes de filtrar.

---

## Test plan
- [x] `npx tsc --noEmit` — limpo
- [x] `npm test` — 12 suites, 121 testes, 0 falhas
- [x] Sintaxe do `dashboard.js` — `node -c` limpo
- [x] Sem referências órfãs a `rangeSelect` / `state.rangeDays` / `nivelChart`
- [x] Zero emojis em HTML/CSS/JS (verificado com regex Unicode)
- [ ] Smoke em browser: Overview → mudar preset para "Hoy", verificar que Academic/Turmas/Commercial não refazem fetch
- [ ] Smoke em browser: redimensionar para 720px, confirmar que menu vira hamburger e drawer abre/fecha
- [ ] Smoke em browser: trocar moeda, validar que re-renderiza sem refetch
- [ ] Verificar com dados reais do Q10 que a aba Turmas lista cursos abertos (fix do `Estado="Abierto"`)

https://claude.ai/code/session_01GJarYvsaJrh1SZPznRsiDo