### PR TITLE
fix(risk-analysis): correct GRADE_THRESHOLD to 0-10 scale

### DIFF
--- a/src/q10/dashboard/risk-analysis.service.ts
+++ b/src/q10/dashboard/risk-analysis.service.ts
@@ -14,7 +14,7 @@ import {
  * single place and can be referenced from tests / docs if needed.
  */
 export const ABSENCE_THRESHOLD = 20;   // % inasistencia above which we flag
-export const GRADE_THRESHOLD = 0.6;    // Promedio_evaluacion below which we flag
+export const GRADE_THRESHOLD = 6.0;    // Promedio_evaluacion below which we flag (0-10 scale — confirmed via Q10 probe)
 export const STALL_MULTIPLIER = 1.5;   // behind expected progression × this = stalled
 
 /**
@@ -70,7 +70,7 @@ export class RiskAnalysisService {
             : 0;
         const flags: string[] = [];
         if (inasistencia > ABSENCE_THRESHOLD) flags.push(`${Math.round(inasistencia)}% faltas`);
-        if (promedio > 0 && promedio < GRADE_THRESHOLD) flags.push(`nota ${promedio.toFixed(2)}`);
+        if (promedio > 0 && promedio < GRADE_THRESHOLD) flags.push(`nota ${promedio.toFixed(1)}/10`);
         if (modality !== 'Desconocida' && months >= STALL_MULTIPLIER * 3 && behindLevels > 0) {
           flags.push(`${behindLevels} nivel(es) atrás del esperado`);
         }

--- a/test/academic.service.spec.ts
+++ b/test/academic.service.spec.ts
@@ -74,7 +74,7 @@ describe('AcademicService — riskFlags', () => {
         Codigo_estudiante: 'S-CLEAN',
         Nombre_curso: '01 R - Recife',
         Porcentaje_inasistencia: 5,
-        Promedio_evaluacion: 0.85,
+        Promedio_evaluacion: 8.5,
         Porcentaje_evaluado: 80,
       },
     ];
@@ -101,7 +101,7 @@ describe('AcademicService — riskFlags', () => {
         Codigo_estudiante: 'S-ABS',
         Nombre_curso: '01 R - Recife',
         Porcentaje_inasistencia: 35,
-        Promedio_evaluacion: 0.85,
+        Promedio_evaluacion: 8.5,
         Porcentaje_evaluado: 80,
       },
     ];
@@ -115,7 +115,7 @@ describe('AcademicService — riskFlags', () => {
     );
   });
 
-  it('flags a student with promedio below threshold ("nota 0.40")', async () => {
+  it('flags a student with promedio below threshold ("nota 4.0/10")', async () => {
     const students = [
       {
         Codigo_estudiante: 'S-LOW',
@@ -130,7 +130,7 @@ describe('AcademicService — riskFlags', () => {
         Codigo_estudiante: 'S-LOW',
         Nombre_curso: '01 R - Recife',
         Porcentaje_inasistencia: 5,
-        Promedio_evaluacion: 0.4,
+        Promedio_evaluacion: 4.0,
         Porcentaje_evaluado: 80,
       },
     ];
@@ -140,7 +140,7 @@ describe('AcademicService — riskFlags', () => {
 
     expect(result.riskFlags).toHaveLength(1);
     expect(result.riskFlags[0].flags).toEqual(
-      expect.arrayContaining([expect.stringContaining('nota 0.40')]),
+      expect.arrayContaining([expect.stringContaining('nota 4.0/10')]),
     );
   });
 
@@ -189,7 +189,7 @@ describe('AcademicService — riskFlags', () => {
         Codigo_estudiante: 'S-STALL',
         Nombre_curso: '01 R - Recife',
         Porcentaje_inasistencia: 5,
-        Promedio_evaluacion: 0.85,
+        Promedio_evaluacion: 8.5,
         Porcentaje_evaluado: 80,
       },
     ];
@@ -219,7 +219,7 @@ describe('AcademicService — riskFlags', () => {
         Codigo_estudiante: 'S-UNK',
         Nombre_curso: 'Curso raro sin patrón',
         Porcentaje_inasistencia: 5,
-        Promedio_evaluacion: 0.85,
+        Promedio_evaluacion: 8.5,
         Porcentaje_evaluado: 80,
       },
     ];
@@ -264,7 +264,7 @@ describe('AcademicService — riskFlags', () => {
         Codigo_estudiante: 'S-ONE-HIGH',
         Nombre_curso: '01 R - Recife',
         Porcentaje_inasistencia: 40,
-        Promedio_evaluacion: 0.85,
+        Promedio_evaluacion: 8.5,
         Porcentaje_evaluado: 80,
       },
       {
@@ -272,14 +272,14 @@ describe('AcademicService — riskFlags', () => {
         Codigo_estudiante: 'S-THREE',
         Nombre_curso: '01 R - Recife',
         Porcentaje_inasistencia: 25,
-        Promedio_evaluacion: 0.3,
+        Promedio_evaluacion: 3.0,
         Porcentaje_evaluado: 80,
       },
       {
         Codigo_estudiante: 'S-ONE-LOW',
         Nombre_curso: '01 R - Recife',
         Porcentaje_inasistencia: 22,
-        Promedio_evaluacion: 0.85,
+        Promedio_evaluacion: 8.5,
         Porcentaje_evaluado: 80,
       },
     ];
@@ -326,21 +326,21 @@ describe('AcademicService — riskFlags', () => {
         Codigo_estudiante: 'S-FLAGGED-1',
         Nombre_curso: '01 R - Recife',
         Porcentaje_inasistencia: 50,
-        Promedio_evaluacion: 0.85,
+        Promedio_evaluacion: 8.5,
         Porcentaje_evaluado: 80,
       },
       {
         Codigo_estudiante: 'S-FLAGGED-2',
         Nombre_curso: '01 R - Recife',
         Porcentaje_inasistencia: 5,
-        Promedio_evaluacion: 0.35,
+        Promedio_evaluacion: 3.5,
         Porcentaje_evaluado: 80,
       },
       {
         Codigo_estudiante: 'S-CLEAN-2',
         Nombre_curso: '01 R - Recife',
         Porcentaje_inasistencia: 5,
-        Promedio_evaluacion: 0.85,
+        Promedio_evaluacion: 8.5,
         Porcentaje_evaluado: 80,
       },
     ];


### PR DESCRIPTION
## Summary

- `GRADE_THRESHOLD` corrigido de `0.6` para `6.0` — Q10 usa escala 0-10 em `/evaluaciones.Promedio_evaluacion` (confirmado via probe em 2026-04-22)
- Flag de nota atualizado de `nota X.XX` para `nota X.X/10` (uma casa decimal é suficiente na escala real)
- Fixtures de teste atualizados para escala 0-10 em todos os casos (`0.85 → 8.5`, `0.4 → 4.0`, `0.3 → 3.0`, `0.35 → 3.5`)

## Test Plan

- [x] 8/8 testes passando (`npm test`)
- [x] Aluno com `Promedio_evaluacion: 4.0` agora é sinalizado como `nota 4.0/10`
- [x] Aluno com `Promedio_evaluacion: 8.5` não é sinalizado (acima do threshold)
- [x] Guard `promedio > 0` mantido (nota 0 = sem dados, não é flag)

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)