### PR TITLE
fix(financial): group revenueByConcept by Nombre_producto instead of Nombre_programa

### DIFF
--- a/public/dashboard/index.html
+++ b/public/dashboard/index.html
@@ -384,7 +384,7 @@
             <canvas id="revenueByModalityChart" height="140"></canvas>
           </div>
           <div class="card">
-            <h2 class="card__title">Ingresos por programa</h2>
+            <h2 class="card__title">Ingresos por concepto</h2>
             <canvas id="revenueByProgramChart" height="140"></canvas>
           </div>
         </section>

--- a/src/q10/dashboard/financial.service.ts
+++ b/src/q10/dashboard/financial.service.ts
@@ -185,7 +185,7 @@ export class FinancialService extends DashboardBaseService {
       }));
 
     const revenueByConcept = groupSum(pagos, (p) =>
-      cleanStr(p.Nombre_programa) || 'Sin programa',
+      cleanStr(p.Nombre_producto) || 'Sin concepto',
       'Valor_pagado',
     );
 

--- a/test/financial-segmentation.spec.ts
+++ b/test/financial-segmentation.spec.ts
@@ -72,6 +72,42 @@ describe('FinancialService — modality-segmented revenue', () => {
     expect(result.charts.revenueByModality.Desconocida).toBe(40);
   });
 
+  it('revenueByConcept groups by Nombre_producto, not Nombre_programa', async () => {
+    const pagosWithNullPrograma = [
+      {
+        Codigo_persona: 'P1',
+        Nombre_producto: 'Mensualidad 14 R - Recife',
+        Nombre_programa: null,
+        Valor_pagado: 90,
+        Fecha_pago: '2026-03-01',
+      },
+      {
+        Codigo_persona: 'P2',
+        Nombre_producto: 'Matrícula',
+        Nombre_programa: null,
+        Valor_pagado: 50,
+        Fecha_pago: '2026-03-02',
+      },
+      {
+        Codigo_persona: 'P3',
+        Nombre_producto: 'Mensualidad 14 R - Recife',
+        Nombre_programa: null,
+        Valor_pagado: 90,
+        Fecha_pago: '2026-03-03',
+      },
+    ];
+    const q10 = makeQ10({ '/periodos': [], '/pagos': pagosWithNullPrograma });
+    const svc = new FinancialService(q10);
+
+    const result = await svc.financial(12);
+    const concept = result.charts.revenueByConcept;
+
+    expect(concept['Mensualidad 14 R - Recife']).toBe(180);
+    expect(concept['Matrícula']).toBe(50);
+    expect(concept['Sin programa']).toBeUndefined();
+    expect(concept['Sin concepto']).toBeUndefined();
+  });
+
   it('honours explicit from/to ISO dates', async () => {
     const q10 = makeQ10({
       '/periodos': [],


### PR DESCRIPTION
## Summary

- Troca o agrupamento de `revenueByConcept` de `Nombre_programa` (100% null neste tenant) para `Nombre_producto` (populado: "Mensualidad 14 R - Recife", "Matrícula", etc.)
- Renomeia o label do chart de **"Ingresos por programa"** → **"Ingresos por concepto"**
- Adiciona teste que verifica o novo agrupamento e garante que `"Sin programa"` não aparece

## Test plan

- [x] `test/financial-segmentation.spec.ts` — 4/4 passando (incluindo novo caso)
- [x] Verificado que `Nombre_producto` já é usado em `revenueByModality` — padrão consistente
- [x] Frontend não precisa de mudança — `renderDistributionChart('revenueByProgramChart', data.charts.revenueByConcept, ...)` já consome o campo correto

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)