### PR TITLE
feat(survey): pesquisa de satisfação mensal

### DIFF
--- a/public/admin/pesquisas/index.html
+++ b/public/admin/pesquisas/index.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Pesquisas de Satisfação — Genius Idiomas</title>
+  <meta name="robots" content="noindex, nofollow">
+  <meta name="theme-color" content="#000E38">
+
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@500;600;700&family=Montserrat:wght@400;500;600;700&display=swap" rel="stylesheet">
+
+  <link rel="icon" href="/favicon.ico">
+  <link rel="stylesheet" href="/admin/pesquisas/pesquisas.css">
+</head>
+<body>
+
+<header class="topbar">
+  <div class="topbar__brand">
+    <span class="topbar__title">Pesquisas de Satisfação</span>
+    <span class="topbar__sub">Painel administrativo</span>
+  </div>
+  <nav class="topbar__nav">
+    <a href="/dashboard" class="link">← Dashboard</a>
+    <button id="logoutBtn" class="link link--ghost" type="button">Sair</button>
+  </nav>
+</header>
+
+<main id="app" class="app">
+  <div id="loading" class="loading">Carregando…</div>
+</main>
+
+<!-- ───────── Modal: gerar período ───────── -->
+<div id="generateModal" class="modal hidden" role="dialog" aria-modal="true" aria-labelledby="genTitle">
+  <div class="modal__backdrop" data-close></div>
+  <div class="modal__panel">
+    <h2 id="genTitle">Gerar pesquisa do mês</h2>
+    <p class="modal__sub">Cria um link único por aluno ativo. Não pode ser desfeito — gere com cuidado.</p>
+
+    <form id="generateForm" class="form">
+      <div class="form__row">
+        <label class="form__group">
+          Mês
+          <select name="mes" required>
+            <option value="1">Janeiro</option>
+            <option value="2">Fevereiro</option>
+            <option value="3">Março</option>
+            <option value="4">Abril</option>
+            <option value="5">Maio</option>
+            <option value="6">Junho</option>
+            <option value="7">Julho</option>
+            <option value="8">Agosto</option>
+            <option value="9">Setembro</option>
+            <option value="10">Outubro</option>
+            <option value="11">Novembro</option>
+            <option value="12">Dezembro</option>
+          </select>
+        </label>
+        <label class="form__group">
+          Ano
+          <input type="number" name="ano" required min="2025" max="2100">
+        </label>
+        <label class="form__group">
+          Validade (dias)
+          <input type="number" name="validade_dias" value="7" min="1" max="30">
+        </label>
+      </div>
+
+      <div class="alert alert--error hidden" id="genError"></div>
+
+      <div class="modal__actions">
+        <button type="button" class="btn btn--ghost" data-close>Cancelar</button>
+        <button type="submit" class="btn btn--primary" id="genSubmitBtn">Gerar tokens</button>
+      </div>
+    </form>
+  </div>
+</div>
+
+<script src="/admin/pesquisas/pesquisas.js"></script>
+</body>
+</html>

--- a/public/admin/pesquisas/pesquisas.css
+++ b/public/admin/pesquisas/pesquisas.css
@@ -220,6 +220,16 @@ body {
 }
 
 /* ───────── Per-class WhatsApp blocks ───────── */
+.wa-notice {
+  background: #FFFBEB;
+  border: 1.5px solid #FDE68A;
+  color: #78350F;
+  border-radius: 10px;
+  padding: 0.7rem 0.9rem;
+  font-size: 0.85rem;
+  line-height: 1.45;
+  margin-bottom: 1rem;
+}
 .wa-block {
   background: var(--white);
   border-radius: var(--radius);
@@ -229,7 +239,7 @@ body {
 }
 .wa-block__head {
   display: flex; flex-wrap: wrap; align-items: center;
-  gap: 0.5rem; margin-bottom: 0.5rem;
+  gap: 0.5rem; margin-bottom: 0.75rem;
 }
 .wa-block__title {
   font-weight: 600;
@@ -239,16 +249,40 @@ body {
   font-size: 0.8rem;
   color: var(--gray-text);
 }
-.wa-block__msg {
+.wa-block__body {
+  display: flex; flex-direction: column;
+  gap: 0.75rem;
+}
+.wa-row {
+  display: grid;
+  grid-template-columns: minmax(140px, 1fr) 3fr auto;
+  gap: 0.6rem;
+  align-items: start;
+  border-top: 1px dashed var(--border);
+  padding-top: 0.75rem;
+}
+.wa-row:first-child { border-top: 0; padding-top: 0; }
+.wa-row__name {
+  font-weight: 600;
+  font-size: 0.9rem;
+  padding-top: 0.4rem;
+}
+.wa-row__msg {
   width: 100%;
   border: 1.5px solid var(--border);
   border-radius: 10px;
-  padding: 0.7rem 0.9rem;
+  padding: 0.55rem 0.75rem;
   font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
-  font-size: 0.85rem;
-  line-height: 1.5;
+  font-size: 0.82rem;
+  line-height: 1.45;
   background: var(--cream);
   resize: vertical;
+}
+@media (max-width: 600px) {
+  .wa-row {
+    grid-template-columns: 1fr;
+  }
+  .wa-row__name { padding-top: 0; }
 }
 
 /* ───────── Per-class table ───────── */

--- a/public/admin/pesquisas/pesquisas.css
+++ b/public/admin/pesquisas/pesquisas.css
@@ -1,0 +1,422 @@
+/* Genius admin — pesquisas. Brand palette mirrors dashboard.css. */
+
+:root {
+  --navy: #000E38;
+  --navy-soft: #1a2456;
+  --gold: #DCAF63;
+  --gold-light: #EBC584;
+  --cream: #FFF8EF;
+  --gray-text: #606060;
+  --border: #E5E7EB;
+  --bg: #F5F7FA;
+  --white: #FFFFFF;
+  --success: #10B981;
+  --danger: #EF4444;
+  --warning: #F59E0B;
+  --shadow-sm: 0 1px 2px rgba(0, 14, 56, 0.06);
+  --shadow-md: 0 4px 12px rgba(0, 14, 56, 0.08);
+  --radius: 12px;
+  --font-display: 'Cinzel', 'Times New Roman', serif;
+  --font-body: 'Montserrat', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+
+* { box-sizing: border-box; margin: 0; padding: 0; }
+html, body { height: 100%; }
+body {
+  font-family: var(--font-body);
+  background: var(--bg);
+  color: var(--navy);
+  font-size: 15px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+}
+
+.hidden { display: none !important; }
+
+/* ───────── Topbar ───────── */
+.topbar {
+  background: linear-gradient(135deg, var(--navy) 0%, var(--navy-soft) 100%);
+  color: var(--white);
+  padding: 0.75rem 1.25rem;
+  display: flex; align-items: center; justify-content: space-between;
+  flex-wrap: wrap; gap: 0.75rem;
+}
+.topbar__brand { display: flex; flex-direction: column; }
+.topbar__title {
+  font-family: var(--font-display);
+  font-size: 1.05rem;
+  letter-spacing: 0.06em;
+}
+.topbar__sub { font-size: 0.75rem; opacity: 0.75; }
+
+.topbar__nav { display: flex; align-items: center; gap: 1rem; }
+.link {
+  background: none; border: none; cursor: pointer;
+  color: var(--gold-light); font: inherit; font-weight: 500;
+  text-decoration: none;
+}
+.link:hover { color: var(--white); }
+.link--ghost { font-weight: 400; opacity: 0.85; }
+
+/* ───────── App container ───────── */
+.app {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 1.25rem;
+}
+.loading {
+  background: var(--white);
+  border-radius: var(--radius);
+  padding: 2rem;
+  text-align: center;
+  color: var(--gray-text);
+  box-shadow: var(--shadow-sm);
+}
+.alert {
+  border-radius: 10px;
+  padding: 0.75rem 1rem;
+  font-size: 0.9rem;
+  margin-bottom: 0.85rem;
+}
+.alert--error {
+  background: #FEF2F2;
+  color: var(--danger);
+  border: 1.5px solid #FECACA;
+}
+
+/* ───────── Page header ───────── */
+.page__header {
+  display: flex; flex-wrap: wrap; align-items: center;
+  gap: 0.75rem; margin-bottom: 1.5rem;
+}
+.page__title {
+  font-family: var(--font-display);
+  font-size: 1.4rem;
+  letter-spacing: 0.04em;
+  margin-right: auto;
+}
+.crumb { color: var(--gray-text); font-size: 0.85rem; }
+.crumb a { color: var(--navy); text-decoration: none; }
+.crumb a:hover { text-decoration: underline; }
+
+/* ───────── Buttons ───────── */
+.btn {
+  display: inline-flex; align-items: center; gap: 0.4rem;
+  padding: 0.55rem 1rem;
+  border-radius: 10px;
+  font-family: inherit;
+  font-weight: 600;
+  font-size: 0.9rem;
+  border: 1.5px solid transparent;
+  cursor: pointer;
+  transition: background 150ms, border-color 150ms, color 150ms, transform 100ms;
+}
+.btn:active { transform: translateY(1px); }
+.btn:disabled { opacity: 0.6; cursor: not-allowed; }
+.btn--primary { background: var(--navy); color: var(--gold-light); border-color: var(--navy); }
+.btn--primary:hover:not(:disabled) { background: var(--navy-soft); }
+.btn--ghost { background: var(--white); color: var(--navy); border-color: var(--border); }
+.btn--ghost:hover:not(:disabled) { border-color: var(--navy); }
+.btn--small { padding: 0.4rem 0.75rem; font-size: 0.85rem; }
+
+/* ───────── Period cards (list view) ───────── */
+.cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  gap: 1rem;
+}
+.card {
+  background: var(--white);
+  border-radius: var(--radius);
+  padding: 1.25rem;
+  box-shadow: var(--shadow-sm);
+  text-decoration: none;
+  color: inherit;
+  display: flex; flex-direction: column;
+  gap: 0.5rem;
+  border: 1.5px solid transparent;
+  transition: border-color 150ms, transform 100ms;
+}
+.card:hover {
+  border-color: var(--gold);
+  transform: translateY(-1px);
+}
+.card__title {
+  font-family: var(--font-display);
+  font-size: 1.05rem;
+  letter-spacing: 0.04em;
+  text-transform: capitalize;
+}
+.card__bar {
+  height: 6px;
+  background: var(--border);
+  border-radius: 999px;
+  overflow: hidden;
+}
+.card__bar > div {
+  height: 100%;
+  background: var(--gold);
+  border-radius: 999px;
+}
+.card__stats {
+  display: flex; justify-content: space-between;
+  color: var(--gray-text);
+  font-size: 0.85rem;
+}
+.card__stats strong { color: var(--navy); }
+
+/* ───────── KPI strip (detail view) ───────── */
+.kpis {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 0.75rem;
+  margin-bottom: 1.5rem;
+}
+.kpi {
+  background: var(--white);
+  border-radius: var(--radius);
+  padding: 1rem;
+  box-shadow: var(--shadow-sm);
+}
+.kpi__label {
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  color: var(--gray-text);
+  text-transform: uppercase;
+  margin-bottom: 0.35rem;
+}
+.kpi__value {
+  font-family: var(--font-display);
+  font-size: 1.5rem;
+  letter-spacing: 0.02em;
+}
+.kpi__sub { font-size: 0.75rem; color: var(--gray-text); }
+
+.kpi--good .kpi__value { color: var(--success); }
+.kpi--warn .kpi__value { color: var(--warning); }
+.kpi--bad .kpi__value { color: var(--danger); }
+
+/* ───────── Tabs ───────── */
+.tabs {
+  display: flex;
+  gap: 0.25rem;
+  border-bottom: 1.5px solid var(--border);
+  margin-bottom: 1rem;
+  overflow-x: auto;
+}
+.tab {
+  background: none; border: 0;
+  padding: 0.65rem 1rem;
+  font: inherit; font-weight: 600;
+  color: var(--gray-text);
+  cursor: pointer;
+  border-bottom: 2px solid transparent;
+  white-space: nowrap;
+}
+.tab[aria-selected="true"] {
+  color: var(--navy);
+  border-bottom-color: var(--gold);
+}
+
+/* ───────── Per-class WhatsApp blocks ───────── */
+.wa-block {
+  background: var(--white);
+  border-radius: var(--radius);
+  padding: 1rem 1.25rem;
+  box-shadow: var(--shadow-sm);
+  margin-bottom: 1rem;
+}
+.wa-block__head {
+  display: flex; flex-wrap: wrap; align-items: center;
+  gap: 0.5rem; margin-bottom: 0.5rem;
+}
+.wa-block__title {
+  font-weight: 600;
+  margin-right: auto;
+}
+.wa-block__count {
+  font-size: 0.8rem;
+  color: var(--gray-text);
+}
+.wa-block__msg {
+  width: 100%;
+  border: 1.5px solid var(--border);
+  border-radius: 10px;
+  padding: 0.7rem 0.9rem;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.85rem;
+  line-height: 1.5;
+  background: var(--cream);
+  resize: vertical;
+}
+
+/* ───────── Per-class table ───────── */
+.table-wrap {
+  background: var(--white);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-sm);
+  overflow-x: auto;
+}
+table { width: 100%; border-collapse: collapse; font-size: 0.9rem; }
+th, td {
+  text-align: left;
+  padding: 0.65rem 0.85rem;
+  border-bottom: 1px solid var(--border);
+  vertical-align: top;
+}
+th {
+  font-size: 0.75rem; font-weight: 700;
+  letter-spacing: 0.06em; text-transform: uppercase;
+  color: var(--gray-text); background: #FAFBFC;
+}
+tr:last-child td { border-bottom: 0; }
+tr:hover td { background: rgba(220, 175, 99, 0.06); }
+.table-link {
+  color: var(--navy);
+  text-decoration: none; font-weight: 600;
+}
+.table-link:hover { color: var(--gold); }
+
+/* ───────── Alerts list ───────── */
+.alerts {
+  background: var(--white);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-sm);
+  padding: 1rem 1.25rem;
+}
+.alerts__head {
+  font-family: var(--font-display);
+  font-size: 1rem;
+  margin-bottom: 0.75rem;
+}
+.alert-row {
+  display: flex; flex-wrap: wrap; gap: 0.5rem;
+  padding: 0.6rem 0;
+  border-bottom: 1px dashed var(--border);
+  font-size: 0.9rem;
+}
+.alert-row:last-child { border-bottom: 0; }
+.alert-row__tipo {
+  font-weight: 700;
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  padding: 0.15rem 0.45rem;
+  border-radius: 6px;
+  background: #FEF2F2;
+  color: var(--danger);
+}
+
+/* ───────── Response list (turma view) ───────── */
+.response-card {
+  background: var(--white);
+  border-radius: var(--radius);
+  padding: 1rem 1.25rem;
+  margin-bottom: 0.75rem;
+  box-shadow: var(--shadow-sm);
+}
+.response-card__head {
+  display: flex; flex-wrap: wrap; gap: 1rem;
+  align-items: baseline;
+  margin-bottom: 0.5rem;
+}
+.response-card__date {
+  font-size: 0.8rem;
+  color: var(--gray-text);
+}
+.scores {
+  display: flex; gap: 0.75rem; flex-wrap: wrap;
+}
+.score {
+  font-size: 0.85rem;
+  background: var(--cream);
+  border-radius: 8px;
+  padding: 0.2rem 0.5rem;
+}
+.score strong { color: var(--navy); margin-left: 0.25rem; }
+
+.feedback {
+  background: var(--cream);
+  border-radius: 10px;
+  padding: 0.6rem 0.85rem;
+  margin-top: 0.5rem;
+  font-size: 0.9rem;
+  white-space: pre-wrap;
+}
+.feedback__label {
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--gray-text);
+  margin-bottom: 0.25rem;
+}
+
+.empty {
+  background: var(--white);
+  border-radius: var(--radius);
+  padding: 2.5rem 1.5rem;
+  text-align: center;
+  color: var(--gray-text);
+  box-shadow: var(--shadow-sm);
+}
+.empty__title {
+  font-family: var(--font-display);
+  font-size: 1.1rem;
+  margin-bottom: 0.5rem;
+  color: var(--navy);
+}
+
+/* ───────── Modal ───────── */
+.modal {
+  position: fixed; inset: 0;
+  display: grid; place-items: center;
+  z-index: 50;
+  padding: 1rem;
+}
+.modal__backdrop {
+  position: absolute; inset: 0;
+  background: rgba(0, 14, 56, 0.6);
+  backdrop-filter: blur(2px);
+}
+.modal__panel {
+  position: relative;
+  width: 100%;
+  max-width: 480px;
+  background: var(--white);
+  border-radius: 16px;
+  padding: 1.5rem;
+  box-shadow: 0 20px 50px rgba(0, 14, 56, 0.35);
+}
+.modal__panel h2 {
+  font-family: var(--font-display);
+  font-size: 1.2rem;
+  margin-bottom: 0.35rem;
+}
+.modal__sub { color: var(--gray-text); font-size: 0.9rem; margin-bottom: 1.25rem; }
+.modal__actions {
+  display: flex; justify-content: flex-end; gap: 0.5rem; margin-top: 1rem;
+}
+
+.form__row { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 0.75rem; }
+.form__group { display: flex; flex-direction: column; gap: 0.3rem; font-size: 0.85rem; font-weight: 600; }
+.form__group select,
+.form__group input {
+  padding: 0.55rem 0.75rem;
+  border: 1.5px solid var(--border);
+  border-radius: 8px;
+  font: inherit; font-weight: 400;
+  background: var(--white);
+}
+.form__group select:focus,
+.form__group input:focus {
+  outline: none; border-color: var(--gold);
+  box-shadow: 0 0 0 3px rgba(220, 175, 99, 0.18);
+}
+
+@media (max-width: 600px) {
+  .form__row { grid-template-columns: 1fr; }
+  .topbar { padding: 0.75rem 0.85rem; }
+  .app { padding: 0.85rem; }
+}

--- a/public/admin/pesquisas/pesquisas.js
+++ b/public/admin/pesquisas/pesquisas.js
@@ -192,16 +192,28 @@
       </div>
     `;
 
-    const waBlocks = wa.turmas.map((t) => `
-      <div class="wa-block">
-        <div class="wa-block__head">
-          <span class="wa-block__title">${escapeHtml(t.turma_nome)}${t.professor_nome ? ' · Prof. ' + escapeHtml(t.professor_nome) : ''}</span>
-          <span class="wa-block__count">${t.alunos_count} aluno${t.alunos_count === 1 ? '' : 's'}</span>
-          <button class="btn btn--ghost btn--small" data-copy="wa-${escapeHtml(t.turma_codigo)}">Copiar</button>
+    const waBlocks = wa.turmas.map((t) => {
+      const alunosHtml = t.alunos.map((a) => `
+        <div class="wa-row">
+          <div class="wa-row__name">${escapeHtml(a.aluno_nome)}</div>
+          <textarea class="wa-row__msg" id="wa-${escapeHtml(a.aluno_codigo)}" rows="3" readonly>${escapeHtml(a.mensagem)}</textarea>
+          <button class="btn btn--ghost btn--small" data-copy="wa-${escapeHtml(a.aluno_codigo)}">Copiar</button>
         </div>
-        <textarea class="wa-block__msg" id="wa-${escapeHtml(t.turma_codigo)}" rows="${Math.min(8, t.alunos_count + 2)}" readonly>${escapeHtml(t.mensagem)}</textarea>
-      </div>
-    `).join('');
+      `).join('');
+      return `
+        <div class="wa-block">
+          <div class="wa-block__head">
+            <span class="wa-block__title">${escapeHtml(t.turma_nome)}${t.professor_nome ? ' · Prof. ' + escapeHtml(t.professor_nome) : ''}</span>
+            <span class="wa-block__count">${t.alunos_count} aluno${t.alunos_count === 1 ? '' : 's'}</span>
+          </div>
+          <div class="wa-block__body">${alunosHtml}</div>
+        </div>
+      `;
+    }).join('');
+
+    const waWarning = wa.turmas.length === 0
+      ? ''
+      : `<div class="wa-notice">⚠️ Envie cada link em <strong>conversa privada</strong> com o aluno. O link é a credencial de resposta — se outro aluno o abrir, a pesquisa fica inválida para o aluno real.</div>`;
 
     const turmasRows = detail.por_turma.map((t) => `
       <tr>
@@ -248,6 +260,7 @@
       </div>
 
       <div class="tab-pane" data-pane="whatsapp">
+        ${waWarning}
         ${waBlocks || '<div class="empty">Sem mensagens.</div>'}
       </div>
       <div class="tab-pane hidden" data-pane="turmas">

--- a/public/admin/pesquisas/pesquisas.js
+++ b/public/admin/pesquisas/pesquisas.js
@@ -1,0 +1,415 @@
+// Genius admin — pesquisas SPA.
+// Hash router with three views:
+//   #/                                     → list of periods
+//   #/period/:id                           → detail (KPIs, WhatsApp, alerts, per-class table)
+//   #/period/:id/turma/:turma_codigo       → per-class responses
+
+(() => {
+  'use strict';
+
+  const MES_PT = {
+    1: 'janeiro', 2: 'fevereiro', 3: 'março', 4: 'abril', 5: 'maio', 6: 'junho',
+    7: 'julho', 8: 'agosto', 9: 'setembro', 10: 'outubro', 11: 'novembro', 12: 'dezembro',
+  };
+
+  const ALERT_LABELS = {
+    intencao_critica: 'Intenção de pausar / não continuar',
+    nota_professor_baixa: 'Nota baixa para o professor',
+    nota_aulas_baixa: 'Nota baixa para as aulas',
+  };
+
+  const app = document.getElementById('app');
+  const generateModal = document.getElementById('generateModal');
+  const genForm = document.getElementById('generateForm');
+  const genError = document.getElementById('genError');
+  const genSubmitBtn = document.getElementById('genSubmitBtn');
+
+  // ─── HTTP helpers ───
+  async function api(path, opts = {}) {
+    const resp = await fetch(path, {
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json', ...(opts.headers ?? {}) },
+      ...opts,
+    });
+    if (resp.status === 401) {
+      window.location.href = '/dashboard';
+      throw new Error('not authenticated');
+    }
+    const text = await resp.text();
+    const body = text ? JSON.parse(text) : null;
+    if (!resp.ok) {
+      const err = new Error((body && body.message) || resp.statusText);
+      err.status = resp.status;
+      err.body = body;
+      throw err;
+    }
+    return body;
+  }
+
+  function escapeHtml(s) {
+    if (s == null) return '';
+    return String(s)
+      .replaceAll('&', '&amp;')
+      .replaceAll('<', '&lt;')
+      .replaceAll('>', '&gt;')
+      .replaceAll('"', '&quot;')
+      .replaceAll("'", '&#39;');
+  }
+
+  function fmtMonth(mes, ano) {
+    return `${MES_PT[mes] ?? mes}/${ano}`;
+  }
+  function fmtPercent(num, den) {
+    if (!den) return '0%';
+    return Math.round((num / den) * 100) + '%';
+  }
+  function fmtDate(iso) {
+    if (!iso) return '—';
+    const d = new Date(iso);
+    return d.toLocaleString('pt-BR', { dateStyle: 'short', timeStyle: 'short' });
+  }
+  function kpiClass(value, kind) {
+    if (value == null) return '';
+    if (kind === 'nota') {
+      if (value >= 4) return 'kpi--good';
+      if (value >= 3) return 'kpi--warn';
+      return 'kpi--bad';
+    }
+    if (kind === 'nps') {
+      if (value >= 50) return 'kpi--good';
+      if (value >= 0) return 'kpi--warn';
+      return 'kpi--bad';
+    }
+    return '';
+  }
+
+  // ─── Router ───
+  function parseHash() {
+    const h = (window.location.hash || '#/').replace(/^#/, '');
+    const parts = h.split('/').filter(Boolean);
+    if (parts.length === 0) return { view: 'list' };
+    if (parts[0] === 'period' && parts.length === 2) return { view: 'detail', id: parts[1] };
+    if (parts[0] === 'period' && parts[2] === 'turma' && parts.length === 4) {
+      return { view: 'turma', id: parts[1], turma: parts[3] };
+    }
+    return { view: 'list' };
+  }
+
+  async function render() {
+    app.innerHTML = '<div class="loading">Carregando…</div>';
+    const route = parseHash();
+    try {
+      if (route.view === 'list') await renderList();
+      else if (route.view === 'detail') await renderDetail(route.id);
+      else if (route.view === 'turma') await renderTurma(route.id, route.turma);
+    } catch (err) {
+      app.innerHTML = `<div class="alert alert--error">${escapeHtml(err.message || 'Erro')}</div>`;
+    }
+  }
+
+  // ─── View: list ───
+  async function renderList() {
+    const periods = await api('/api/admin/pesquisas');
+
+    if (periods.length === 0) {
+      app.innerHTML = `
+        <header class="page__header">
+          <h1 class="page__title">Pesquisas de satisfação</h1>
+          <button class="btn btn--primary" id="newBtn">Gerar pesquisa do mês</button>
+        </header>
+        <div class="empty">
+          <p class="empty__title">Nenhuma pesquisa criada ainda</p>
+          <p>Clique em <em>Gerar pesquisa do mês</em> para criar a primeira.</p>
+        </div>
+      `;
+    } else {
+      const cards = periods.map((p) => {
+        const ratio = p.tokens_total > 0 ? p.tokens_respondidos / p.tokens_total : 0;
+        return `
+          <a class="card" href="#/period/${encodeURIComponent(p.id)}">
+            <span class="card__title">${escapeHtml(MES_PT[p.mes_referencia] ?? p.mes_referencia)} · ${escapeHtml(p.ano_referencia)}</span>
+            <div class="card__bar"><div style="width:${(ratio * 100).toFixed(0)}%"></div></div>
+            <div class="card__stats">
+              <span><strong>${p.tokens_respondidos}</strong> / ${p.tokens_total} respondidas</span>
+              <span>${fmtPercent(p.tokens_respondidos, p.tokens_total)}</span>
+            </div>
+            <div class="card__stats">
+              <span>Gerada por ${escapeHtml(p.gerado_por)}</span>
+              <span>${fmtDate(p.criado_em).split(',')[0]}</span>
+            </div>
+          </a>
+        `;
+      }).join('');
+
+      app.innerHTML = `
+        <header class="page__header">
+          <h1 class="page__title">Pesquisas de satisfação</h1>
+          <button class="btn btn--primary" id="newBtn">Gerar pesquisa do mês</button>
+        </header>
+        <div class="cards">${cards}</div>
+      `;
+    }
+
+    document.getElementById('newBtn').addEventListener('click', openGenerateModal);
+  }
+
+  // ─── View: detail ───
+  async function renderDetail(periodId) {
+    const [detail, wa] = await Promise.all([
+      api(`/api/admin/pesquisas/${encodeURIComponent(periodId)}`),
+      api(`/api/admin/pesquisas/${encodeURIComponent(periodId)}/mensagens-whatsapp`),
+    ]);
+
+    const s = detail.summary;
+
+    const kpis = `
+      <div class="kpis">
+        <div class="kpi">
+          <div class="kpi__label">Respondidas</div>
+          <div class="kpi__value">${s.respondidas} / ${s.tokens_total}</div>
+          <div class="kpi__sub">${s.taxa_resposta}%</div>
+        </div>
+        <div class="kpi ${kpiClass(s.media_aulas, 'nota')}">
+          <div class="kpi__label">Média aulas</div>
+          <div class="kpi__value">${s.media_aulas ?? '—'}</div>
+          <div class="kpi__sub">de 5</div>
+        </div>
+        <div class="kpi ${kpiClass(s.media_professor, 'nota')}">
+          <div class="kpi__label">Média professor</div>
+          <div class="kpi__value">${s.media_professor ?? '—'}</div>
+          <div class="kpi__sub">de 5</div>
+        </div>
+        <div class="kpi ${kpiClass(s.media_geral, 'nota')}">
+          <div class="kpi__label">Média geral</div>
+          <div class="kpi__value">${s.media_geral ?? '—'}</div>
+          <div class="kpi__sub">de 5</div>
+        </div>
+        <div class="kpi ${kpiClass(s.nps, 'nps')}">
+          <div class="kpi__label">NPS</div>
+          <div class="kpi__value">${s.nps ?? '—'}</div>
+          <div class="kpi__sub">−100 a +100</div>
+        </div>
+      </div>
+    `;
+
+    const waBlocks = wa.turmas.map((t) => `
+      <div class="wa-block">
+        <div class="wa-block__head">
+          <span class="wa-block__title">${escapeHtml(t.turma_nome)}${t.professor_nome ? ' · Prof. ' + escapeHtml(t.professor_nome) : ''}</span>
+          <span class="wa-block__count">${t.alunos_count} aluno${t.alunos_count === 1 ? '' : 's'}</span>
+          <button class="btn btn--ghost btn--small" data-copy="wa-${escapeHtml(t.turma_codigo)}">Copiar</button>
+        </div>
+        <textarea class="wa-block__msg" id="wa-${escapeHtml(t.turma_codigo)}" rows="${Math.min(8, t.alunos_count + 2)}" readonly>${escapeHtml(t.mensagem)}</textarea>
+      </div>
+    `).join('');
+
+    const turmasRows = detail.por_turma.map((t) => `
+      <tr>
+        <td>
+          <a class="table-link" href="#/period/${encodeURIComponent(periodId)}/turma/${encodeURIComponent(t.turma_codigo)}">
+            ${escapeHtml(t.turma_nome)}
+          </a>
+          ${t.professor_nome ? `<div style="color:var(--gray-text);font-size:0.8rem">Prof. ${escapeHtml(t.professor_nome)}</div>` : ''}
+        </td>
+        <td>${t.respondidas} / ${t.alunos_count}</td>
+        <td>${fmtPercent(t.respondidas, t.alunos_count)}</td>
+        <td>${t.media_aulas ?? '—'}</td>
+        <td>${t.media_professor ?? '—'}</td>
+        <td>${t.media_geral ?? '—'}</td>
+      </tr>
+    `).join('');
+
+    const alertsBlock = detail.alertas.length === 0
+      ? ''
+      : `
+        <div class="alerts">
+          <div class="alerts__head">Alertas (${detail.alertas.length})</div>
+          ${detail.alertas.map((a) => `
+            <div class="alert-row">
+              <span class="alert-row__tipo">${escapeHtml(ALERT_LABELS[a.tipo] ?? a.tipo)}</span>
+              <span style="flex:1">Turma ${escapeHtml(a.turma_codigo)} · ${escapeHtml(a.detalhe)}</span>
+              <span style="color:var(--gray-text);font-size:0.8rem">${fmtDate(a.criado_em)}</span>
+            </div>
+          `).join('')}
+        </div>
+      `;
+
+    app.innerHTML = `
+      <div class="crumb"><a href="#/">Pesquisas</a> / ${escapeHtml(fmtMonth(detail.period.mes_referencia, detail.period.ano_referencia))}</div>
+      <header class="page__header">
+        <h1 class="page__title" style="text-transform:capitalize">${escapeHtml(fmtMonth(detail.period.mes_referencia, detail.period.ano_referencia))}</h1>
+      </header>
+      ${kpis}
+
+      <div class="tabs" role="tablist">
+        <button class="tab" role="tab" aria-selected="true"  data-tab="whatsapp">Mensagens WhatsApp</button>
+        <button class="tab" role="tab" aria-selected="false" data-tab="turmas">Por turma</button>
+        ${detail.alertas.length ? '<button class="tab" role="tab" aria-selected="false" data-tab="alertas">Alertas</button>' : ''}
+      </div>
+
+      <div class="tab-pane" data-pane="whatsapp">
+        ${waBlocks || '<div class="empty">Sem mensagens.</div>'}
+      </div>
+      <div class="tab-pane hidden" data-pane="turmas">
+        <div class="table-wrap"><table>
+          <thead><tr>
+            <th>Turma</th><th>Respondidas</th><th>%</th>
+            <th>Média aulas</th><th>Média professor</th><th>Média geral</th>
+          </tr></thead>
+          <tbody>${turmasRows}</tbody>
+        </table></div>
+      </div>
+      <div class="tab-pane hidden" data-pane="alertas">${alertsBlock}</div>
+    `;
+
+    // Tab switching
+    app.querySelectorAll('.tab').forEach((btn) => {
+      btn.addEventListener('click', () => {
+        app.querySelectorAll('.tab').forEach((b) => b.setAttribute('aria-selected', String(b === btn)));
+        const which = btn.dataset.tab;
+        app.querySelectorAll('.tab-pane').forEach((p) => p.classList.toggle('hidden', p.dataset.pane !== which));
+      });
+    });
+
+    // Copy to clipboard
+    app.querySelectorAll('[data-copy]').forEach((btn) => {
+      btn.addEventListener('click', async () => {
+        const ta = document.getElementById(btn.dataset.copy);
+        try {
+          await navigator.clipboard.writeText(ta.value);
+          const old = btn.textContent;
+          btn.textContent = 'Copiado!';
+          setTimeout(() => { btn.textContent = old; }, 1500);
+        } catch {
+          ta.select(); document.execCommand('copy');
+        }
+      });
+    });
+  }
+
+  // ─── View: turma detail ───
+  async function renderTurma(periodId, turmaCodigo) {
+    const detail = await api(
+      `/api/admin/pesquisas/${encodeURIComponent(periodId)}/turma/${encodeURIComponent(turmaCodigo)}`,
+    );
+
+    const responsesHtml = detail.respostas.length === 0
+      ? '<div class="empty"><p class="empty__title">Nenhuma resposta ainda</p></div>'
+      : detail.respostas.map((r) => {
+          const feedbacks = [
+            ['Conteúdo', r.feedback_conteudo],
+            ['Professor', r.feedback_professor],
+            ['Escola', r.feedback_escola],
+            ['Situação pessoal', r.situacao_pessoal],
+          ].filter(([, v]) => v).map(([label, v]) => `
+            <div class="feedback">
+              <div class="feedback__label">${label}</div>
+              ${escapeHtml(v)}
+            </div>
+          `).join('');
+          return `
+            <article class="response-card">
+              <header class="response-card__head">
+                <strong>Resposta anônima</strong>
+                <span class="response-card__date">${fmtDate(r.respondido_em)}</span>
+              </header>
+              <div class="scores">
+                <span class="score">Aulas <strong>${r.nota_aulas}</strong></span>
+                <span class="score">Professor <strong>${r.nota_professor}</strong></span>
+                <span class="score">Geral <strong>${r.nota_geral}</strong></span>
+                <span class="score">Recomendaria: <strong>${escapeHtml(r.recomendacao)}</strong></span>
+                <span class="score">Intenção: <strong>${escapeHtml(r.intencao_continuar)}</strong></span>
+              </div>
+              <div class="scores" style="margin-top:0.4rem">
+                <span class="score">Progresso: <strong>${escapeHtml(r.progresso)}</strong></span>
+                <span class="score">Ritmo: <strong>${escapeHtml(r.ritmo)}</strong></span>
+                <span class="score">Pontualidade: <strong>${escapeHtml(r.pontualidade)}</strong></span>
+                <span class="score">Tarefas: <strong>${escapeHtml(r.tarefas)}</strong></span>
+                <span class="score">Atendimento: <strong>${escapeHtml(r.atendimento)}</strong></span>
+              </div>
+              ${feedbacks}
+            </article>
+          `;
+        }).join('');
+
+    app.innerHTML = `
+      <div class="crumb">
+        <a href="#/">Pesquisas</a> /
+        <a href="#/period/${encodeURIComponent(periodId)}">${escapeHtml(fmtMonth(detail.period.mes_referencia, detail.period.ano_referencia))}</a> /
+        ${escapeHtml(detail.turma.turma_nome)}
+      </div>
+      <header class="page__header">
+        <h1 class="page__title">${escapeHtml(detail.turma.turma_nome)}</h1>
+      </header>
+      <div class="kpis">
+        ${detail.turma.professor_nome ? `
+          <div class="kpi">
+            <div class="kpi__label">Professor</div>
+            <div class="kpi__value" style="font-size:1.05rem">${escapeHtml(detail.turma.professor_nome)}</div>
+          </div>` : ''}
+        <div class="kpi">
+          <div class="kpi__label">Respondidas</div>
+          <div class="kpi__value">${detail.respondidas} / ${detail.alunos_count}</div>
+          <div class="kpi__sub">${fmtPercent(detail.respondidas, detail.alunos_count)}</div>
+        </div>
+      </div>
+      ${responsesHtml}
+    `;
+  }
+
+  // ─── Generate modal ───
+  function openGenerateModal() {
+    genError.classList.add('hidden');
+    genForm.reset();
+    const now = new Date();
+    genForm.elements.mes.value = now.getMonth() + 1;
+    genForm.elements.ano.value = now.getFullYear();
+    generateModal.classList.remove('hidden');
+  }
+  function closeGenerateModal() {
+    generateModal.classList.add('hidden');
+  }
+  generateModal.addEventListener('click', (ev) => {
+    if (ev.target.matches('[data-close]')) closeGenerateModal();
+  });
+  genForm.addEventListener('submit', async (ev) => {
+    ev.preventDefault();
+    genError.classList.add('hidden');
+    genSubmitBtn.disabled = true;
+
+    const data = Object.fromEntries(new FormData(genForm).entries());
+    const payload = {
+      mes: Number(data.mes),
+      ano: Number(data.ano),
+      validade_dias: Number(data.validade_dias) || 7,
+    };
+
+    try {
+      const resp = await api('/api/admin/pesquisas/gerar', {
+        method: 'POST',
+        body: JSON.stringify(payload),
+      });
+      closeGenerateModal();
+      window.location.hash = `#/period/${resp.period.id}`;
+    } catch (err) {
+      const msg = (err.body && err.body.message) || err.message || 'Erro';
+      genError.textContent = Array.isArray(msg) ? msg.join(' · ') : msg;
+      genError.classList.remove('hidden');
+    } finally {
+      genSubmitBtn.disabled = false;
+    }
+  });
+
+  // ─── Logout ───
+  document.getElementById('logoutBtn').addEventListener('click', async () => {
+    try {
+      await fetch('/api/auth/logout', { method: 'POST', credentials: 'include' });
+    } finally {
+      window.location.href = '/dashboard';
+    }
+  });
+
+  // ─── Boot ───
+  window.addEventListener('hashchange', render);
+  render();
+})();

--- a/public/pesquisa/index.html
+++ b/public/pesquisa/index.html
@@ -1,0 +1,271 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+  <title>Encuesta mensual — Genius Idiomas</title>
+  <meta name="robots" content="noindex, nofollow">
+  <meta name="theme-color" content="#000E38">
+
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@500;600;700&family=Montserrat:wght@400;500;600;700&display=swap" rel="stylesheet">
+
+  <link rel="icon" href="/favicon.ico">
+  <link rel="stylesheet" href="/pesquisa/pesquisa.css">
+</head>
+<body>
+
+<main class="survey">
+
+  <!-- ───────── Loading state ───────── -->
+  <section id="state-loading" class="state state--loading" aria-live="polite">
+    <div class="spinner"></div>
+    <p>Cargando encuesta…</p>
+  </section>
+
+  <!-- ───────── Error state (404 / 410) ───────── -->
+  <section id="state-error" class="state state--error hidden" aria-live="polite">
+    <div class="state__icon" aria-hidden="true">!</div>
+    <h1 class="state__title">Enlace no válido</h1>
+    <p class="state__msg" id="errorMsg">Este enlace ya no se puede usar.</p>
+    <p class="state__sub">Si crees que es un error, escríbenos por WhatsApp.</p>
+  </section>
+
+  <!-- ───────── Intro (no token) ───────── -->
+  <section id="state-intro" class="state state--intro hidden">
+    <h1 class="state__title">Encuesta mensual</h1>
+    <p class="state__msg">
+      Cada mes enviamos a cada estudiante un enlace personal para responder
+      una encuesta corta sobre las clases. Si llegaste aquí sin enlace,
+      pídele al equipo que te lo reenvíe.
+    </p>
+  </section>
+
+  <!-- ───────── Form ───────── -->
+  <section id="state-form" class="state state--form hidden">
+    <header class="survey__header">
+      <div class="survey__brand">Genius Idiomas</div>
+      <div class="survey__group" id="groupBadge">
+        <span id="turmaName">—</span>
+        <span class="dot" aria-hidden="true">·</span>
+        <span id="profName">—</span>
+      </div>
+      <div class="survey__meta">
+        <span id="periodLabel">—</span>
+      </div>
+      <div class="progress" aria-hidden="true">
+        <div class="progress__bar" id="progressBar" style="width:0%"></div>
+      </div>
+    </header>
+
+    <form id="surveyForm" class="survey__form" novalidate>
+
+      <!-- ─── Section 1: Aulas ─── -->
+      <fieldset class="section" data-section="1">
+        <legend class="section__legend">
+          <span class="section__step">1 / 4</span>
+          <span class="section__title">Sobre las clases</span>
+        </legend>
+
+        <div class="q">
+          <p class="q__label">¿Cómo calificas las clases este mes?</p>
+          <div class="rating" role="radiogroup" aria-label="Nota de las clases">
+            <!-- 5 stars/numbers populated by JS -->
+          </div>
+          <input type="hidden" name="nota_aulas" required>
+        </div>
+
+        <div class="q">
+          <p class="q__label">¿Sentiste que progresaste?</p>
+          <div class="opts" data-name="progresso">
+            <label><input type="radio" name="progresso" value="mucho_progreso" required> Mucho progreso</label>
+            <label><input type="radio" name="progresso" value="un_poco"> Un poco</label>
+            <label><input type="radio" name="progresso" value="no_lo_noto"> No lo noto</label>
+            <label><input type="radio" name="progresso" value="retrocediendo"> Siento que retrocedí</label>
+          </div>
+        </div>
+
+        <div class="q">
+          <p class="q__label">¿Cómo está el ritmo?</p>
+          <div class="opts" data-name="ritmo">
+            <label><input type="radio" name="ritmo" value="perfecto" required> Perfecto</label>
+            <label><input type="radio" name="ritmo" value="un_poco_rapido"> Un poco rápido</label>
+            <label><input type="radio" name="ritmo" value="un_poco_lento"> Un poco lento</label>
+            <label><input type="radio" name="ritmo" value="muy_rapido"> Muy rápido</label>
+          </div>
+        </div>
+
+        <div class="q">
+          <p class="q__label">¿Las clases empiezan a tiempo?</p>
+          <div class="opts" data-name="pontualidade">
+            <label><input type="radio" name="pontualidade" value="siempre" required> Siempre</label>
+            <label><input type="radio" name="pontualidade" value="casi_siempre"> Casi siempre</label>
+            <label><input type="radio" name="pontualidade" value="a_veces_demoras"> A veces se demora</label>
+            <label><input type="radio" name="pontualidade" value="frecuentemente_demoras"> Frecuentemente se demora</label>
+          </div>
+        </div>
+
+        <div class="q">
+          <p class="q__label">¿Y las tareas?</p>
+          <div class="opts" data-name="tarefas">
+            <label><input type="radio" name="tarefas" value="bien" required> Bien, en su punto</label>
+            <label><input type="radio" name="tarefas" value="un_poco_faciles"> Un poco fáciles</label>
+            <label><input type="radio" name="tarefas" value="un_poco_dificiles"> Un poco difíciles</label>
+            <label><input type="radio" name="tarefas" value="muy_dificiles"> Muy difíciles</label>
+            <label><input type="radio" name="tarefas" value="no_hubo"> No hubo tareas</label>
+            <label><input type="radio" name="tarefas" value="mas_tareas"> Me gustaría tener más</label>
+          </div>
+        </div>
+
+        <div class="q">
+          <label class="q__label" for="feedback_conteudo">¿Algo que comentar sobre el contenido? <span class="opt">(opcional)</span></label>
+          <textarea id="feedback_conteudo" name="feedback_conteudo" rows="3" maxlength="2000"></textarea>
+        </div>
+
+        <div class="section__nav">
+          <button type="button" class="btn btn--primary" data-next>Continuar</button>
+        </div>
+      </fieldset>
+
+      <!-- ─── Section 2: Profesor ─── -->
+      <fieldset class="section hidden" data-section="2">
+        <legend class="section__legend">
+          <span class="section__step">2 / 4</span>
+          <span class="section__title">Sobre tu profesor/a</span>
+        </legend>
+
+        <div class="q">
+          <p class="q__label">¿Cómo calificas a tu profesor/a?</p>
+          <div class="rating" role="radiogroup" aria-label="Nota del profesor"></div>
+          <input type="hidden" name="nota_professor" required>
+        </div>
+
+        <div class="q">
+          <p class="q__label">¿El profesor/a explica bien?</p>
+          <div class="opts" data-name="professor_explica">
+            <label><input type="radio" name="professor_explica" value="siempre" required> Siempre</label>
+            <label><input type="radio" name="professor_explica" value="casi_siempre"> Casi siempre</label>
+            <label><input type="radio" name="professor_explica" value="a_veces_no"> A veces no</label>
+            <label><input type="radio" name="professor_explica" value="generalmente_no"> Generalmente no</label>
+          </div>
+        </div>
+
+        <div class="q">
+          <p class="q__label">¿Las clases son dinámicas?</p>
+          <div class="opts" data-name="aulas_dinamicas">
+            <label><input type="radio" name="aulas_dinamicas" value="siempre" required> Siempre</label>
+            <label><input type="radio" name="aulas_dinamicas" value="casi_siempre"> Casi siempre</label>
+            <label><input type="radio" name="aulas_dinamicas" value="a_veces_monotonas"> A veces son monótonas</label>
+            <label><input type="radio" name="aulas_dinamicas" value="cuesta_atencion"> Me cuesta prestar atención</label>
+          </div>
+        </div>
+
+        <div class="q">
+          <label class="q__label" for="feedback_professor">¿Algo más sobre tu profesor/a? <span class="opt">(opcional)</span></label>
+          <textarea id="feedback_professor" name="feedback_professor" rows="3" maxlength="2000"></textarea>
+        </div>
+
+        <div class="section__nav">
+          <button type="button" class="btn btn--ghost" data-prev>Volver</button>
+          <button type="button" class="btn btn--primary" data-next>Continuar</button>
+        </div>
+      </fieldset>
+
+      <!-- ─── Section 3: Experiencia general ─── -->
+      <fieldset class="section hidden" data-section="3">
+        <legend class="section__legend">
+          <span class="section__step">3 / 4</span>
+          <span class="section__title">Tu experiencia general</span>
+        </legend>
+
+        <div class="q">
+          <p class="q__label">Calificación general de Genius este mes</p>
+          <div class="rating" role="radiogroup" aria-label="Nota general"></div>
+          <input type="hidden" name="nota_geral" required>
+        </div>
+
+        <div class="q">
+          <p class="q__label">¿Recomendarías Genius a un amigo?</p>
+          <div class="opts" data-name="recomendacao">
+            <label><input type="radio" name="recomendacao" value="definitivamente" required> Definitivamente sí</label>
+            <label><input type="radio" name="recomendacao" value="probablemente_si"> Probablemente sí</label>
+            <label><input type="radio" name="recomendacao" value="no_seguro"> No estoy seguro/a</label>
+            <label><input type="radio" name="recomendacao" value="probablemente_no"> Probablemente no</label>
+            <label><input type="radio" name="recomendacao" value="no_recomendaria"> No lo recomendaría</label>
+          </div>
+        </div>
+
+        <div class="q">
+          <p class="q__label">¿Cómo es la atención del equipo administrativo?</p>
+          <div class="opts" data-name="atendimento">
+            <label><input type="radio" name="atendimento" value="excelente" required> Excelente</label>
+            <label><input type="radio" name="atendimento" value="buena"> Buena</label>
+            <label><input type="radio" name="atendimento" value="regular"> Regular</label>
+            <label><input type="radio" name="atendimento" value="mala"> Mala</label>
+          </div>
+        </div>
+
+        <div class="q">
+          <p class="q__label">¿Cómo te sientes con tu curso?</p>
+          <div class="opts" data-name="intencao_continuar">
+            <label><input type="radio" name="intencao_continuar" value="comprometido" required> Comprometido/a, voy a seguir</label>
+            <label><input type="radio" name="intencao_continuar" value="siguiendo"> Siguiendo el ritmo</label>
+            <label><input type="radio" name="intencao_continuar" value="desmotivado"> Algo desmotivado/a</label>
+            <label><input type="radio" name="intencao_continuar" value="pensando_pausa"> Pensando en hacer una pausa</label>
+            <label><input type="radio" name="intencao_continuar" value="considerando_no_continuar"> Considerando no continuar</label>
+          </div>
+        </div>
+
+        <div class="section__nav">
+          <button type="button" class="btn btn--ghost" data-prev>Volver</button>
+          <button type="button" class="btn btn--primary" data-next>Continuar</button>
+        </div>
+      </fieldset>
+
+      <!-- ─── Section 4: Comentarios libres ─── -->
+      <fieldset class="section hidden" data-section="4">
+        <legend class="section__legend">
+          <span class="section__step">4 / 4</span>
+          <span class="section__title">Comentarios libres <span class="opt">(opcional)</span></span>
+        </legend>
+
+        <div class="q">
+          <label class="q__label" for="feedback_escola">¿Algo más sobre la escuela?</label>
+          <textarea id="feedback_escola" name="feedback_escola" rows="3" maxlength="2000"
+                    placeholder="Lo que quieras compartir."></textarea>
+        </div>
+
+        <div class="q">
+          <label class="q__label" for="situacao_pessoal">¿Hay algo que esté afectando tus estudios y nos quieras contar?</label>
+          <textarea id="situacao_pessoal" name="situacao_pessoal" rows="3" maxlength="2000"
+                    placeholder="Trabajo, salud, familia… solo si quieres compartir."></textarea>
+        </div>
+
+        <div class="alert alert--error hidden" id="submitError"></div>
+
+        <div class="section__nav">
+          <button type="button" class="btn btn--ghost" data-prev>Volver</button>
+          <button type="submit" class="btn btn--primary" id="submitBtn">Enviar respuestas</button>
+        </div>
+      </fieldset>
+
+    </form>
+  </section>
+
+  <!-- ───────── Thank-you state ───────── -->
+  <section id="state-thanks" class="state state--thanks hidden">
+    <div class="state__icon state__icon--success" aria-hidden="true">✓</div>
+    <h1 class="state__title">¡Gracias por responder!</h1>
+    <p class="state__msg">
+      Tus respuestas son anónimas para tus profesores y nos ayudan a mejorar
+      las clases todos los meses.
+    </p>
+    <p class="state__sub">Que tengas un excelente mes en Genius. 🌟</p>
+  </section>
+
+</main>
+
+<script src="/pesquisa/pesquisa.js"></script>
+</body>
+</html>

--- a/public/pesquisa/pesquisa.css
+++ b/public/pesquisa/pesquisa.css
@@ -1,0 +1,275 @@
+/* Genius Idiomas — survey page (Spanish, mobile-first).
+   Brand palette mirrors public/dashboard/dashboard.css and styles.css. */
+
+:root {
+  --navy: #000E38;
+  --navy-soft: #1a2456;
+  --gold: #DCAF63;
+  --gold-light: #EBC584;
+  --cream: #FFF8EF;
+  --gray-text: #606060;
+  --border: #E5E7EB;
+  --bg: #F5F7FA;
+  --white: #FFFFFF;
+  --success: #10B981;
+  --danger: #EF4444;
+  --shadow-md: 0 4px 12px rgba(0, 14, 56, 0.08);
+  --radius: 12px;
+  --font-display: 'Cinzel', 'Times New Roman', serif;
+  --font-body: 'Montserrat', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+
+* { box-sizing: border-box; margin: 0; padding: 0; }
+html, body { height: 100%; }
+body {
+  font-family: var(--font-body);
+  background: var(--bg);
+  color: var(--navy);
+  font-size: 16px;
+  line-height: 1.55;
+  -webkit-font-smoothing: antialiased;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.hidden { display: none !important; }
+
+.survey { max-width: 640px; margin: 0 auto; padding: 1rem; min-height: 100%; }
+
+/* ───────── Generic state cards ───────── */
+.state {
+  background: var(--white);
+  border-radius: 16px;
+  padding: 2rem 1.5rem;
+  box-shadow: var(--shadow-md);
+  text-align: center;
+  margin-top: 1.5rem;
+}
+.state__icon {
+  width: 56px; height: 56px;
+  border-radius: 50%;
+  display: grid; place-items: center;
+  margin: 0 auto 1rem;
+  background: var(--cream);
+  color: var(--navy);
+  font-size: 1.6rem;
+  font-weight: 700;
+}
+.state__icon--success { background: var(--success); color: var(--white); }
+.state--error .state__icon { background: var(--danger); color: var(--white); }
+.state__title {
+  font-family: var(--font-display);
+  font-size: 1.5rem;
+  margin-bottom: 0.5rem;
+  letter-spacing: 0.04em;
+}
+.state__msg { color: var(--gray-text); margin-bottom: 0.5rem; }
+.state__sub { color: var(--gray-text); font-size: 0.9rem; }
+
+.spinner {
+  width: 36px; height: 36px;
+  border: 3px solid var(--border);
+  border-top-color: var(--gold);
+  border-radius: 50%;
+  margin: 0 auto 1rem;
+  animation: spin 700ms linear infinite;
+}
+@keyframes spin { to { transform: rotate(360deg); } }
+
+/* ───────── Header ───────── */
+.survey__header {
+  background: linear-gradient(135deg, var(--navy) 0%, var(--navy-soft) 100%);
+  color: var(--white);
+  border-radius: 16px 16px 0 0;
+  padding: 1.25rem 1.25rem 1rem;
+  margin-top: 1rem;
+}
+.survey__brand {
+  font-family: var(--font-display);
+  font-size: 1rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--gold-light);
+  margin-bottom: 0.5rem;
+}
+.survey__group {
+  font-size: 1.05rem;
+  font-weight: 600;
+  margin-bottom: 0.25rem;
+}
+.survey__group .dot { margin: 0 0.4rem; opacity: 0.7; }
+.survey__meta { font-size: 0.85rem; opacity: 0.85; margin-bottom: 0.85rem; text-transform: capitalize; }
+
+.progress {
+  height: 6px;
+  background: rgba(255,255,255,0.12);
+  border-radius: 999px;
+  overflow: hidden;
+}
+.progress__bar {
+  height: 100%;
+  background: var(--gold);
+  border-radius: 999px;
+  transition: width 250ms ease;
+}
+
+/* ───────── Form ───────── */
+.survey__form {
+  background: var(--white);
+  border-radius: 0 0 16px 16px;
+  padding: 1.5rem 1.25rem 1.5rem;
+  box-shadow: var(--shadow-md);
+}
+
+.section { border: 0; }
+.section__legend {
+  display: flex; flex-wrap: wrap; align-items: baseline; gap: 0.6rem;
+  margin-bottom: 1.25rem;
+}
+.section__step {
+  font-size: 0.75rem;
+  font-weight: 700;
+  color: var(--gold);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+.section__title {
+  font-family: var(--font-display);
+  font-size: 1.2rem;
+  letter-spacing: 0.04em;
+}
+.opt {
+  font-weight: 400;
+  color: var(--gray-text);
+  font-size: 0.85rem;
+}
+
+.q { margin-bottom: 1.5rem; }
+.q__label {
+  font-weight: 600;
+  margin-bottom: 0.6rem;
+  font-size: 0.95rem;
+}
+
+/* ─── Rating (1–5) ─── */
+.rating {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 0.5rem;
+}
+.rating__btn {
+  appearance: none;
+  background: var(--white);
+  border: 1.5px solid var(--border);
+  border-radius: 10px;
+  padding: 0.85rem 0;
+  font-family: inherit;
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--navy);
+  cursor: pointer;
+  transition: border-color 150ms, background 150ms, color 150ms, transform 100ms;
+}
+.rating__btn:hover { border-color: var(--gold); }
+.rating__btn:active { transform: scale(0.97); }
+.rating__btn[aria-checked="true"] {
+  background: var(--navy);
+  border-color: var(--navy);
+  color: var(--gold-light);
+}
+
+/* ─── Radio options ─── */
+.opts {
+  display: grid;
+  gap: 0.5rem;
+}
+.opts label {
+  display: flex; align-items: flex-start; gap: 0.65rem;
+  border: 1.5px solid var(--border);
+  border-radius: 10px;
+  padding: 0.7rem 0.9rem;
+  cursor: pointer;
+  font-size: 0.95rem;
+  transition: border-color 150ms, background 150ms;
+}
+.opts label:hover { border-color: var(--gold); }
+.opts input[type="radio"] {
+  margin-top: 0.25rem;
+  accent-color: var(--navy);
+  flex-shrink: 0;
+}
+.opts label:has(input:checked) {
+  border-color: var(--navy);
+  background: var(--cream);
+}
+
+textarea {
+  width: 100%;
+  border: 1.5px solid var(--border);
+  border-radius: 10px;
+  padding: 0.7rem 0.9rem;
+  font-family: inherit;
+  font-size: 0.95rem;
+  resize: vertical;
+  background: var(--white);
+  transition: border-color 150ms, box-shadow 150ms;
+}
+textarea:focus {
+  outline: none;
+  border-color: var(--gold);
+  box-shadow: 0 0 0 3px rgba(220, 175, 99, 0.18);
+}
+
+/* ─── Buttons / nav ─── */
+.section__nav {
+  display: flex; gap: 0.75rem;
+  margin-top: 0.5rem;
+}
+.btn {
+  flex: 1;
+  display: inline-flex; justify-content: center; align-items: center;
+  gap: 0.4rem;
+  padding: 0.85rem 1rem;
+  border-radius: 10px;
+  font-family: inherit;
+  font-weight: 600;
+  font-size: 0.95rem;
+  border: 1.5px solid transparent;
+  cursor: pointer;
+  transition: background 150ms, border-color 150ms, color 150ms, transform 100ms;
+}
+.btn:active { transform: translateY(1px); }
+.btn:disabled { opacity: 0.6; cursor: not-allowed; }
+
+.btn--primary {
+  background: var(--navy);
+  color: var(--gold-light);
+  border-color: var(--navy);
+}
+.btn--primary:hover:not(:disabled) {
+  background: var(--navy-soft);
+}
+.btn--ghost {
+  background: var(--white);
+  color: var(--navy);
+  border-color: var(--border);
+}
+.btn--ghost:hover:not(:disabled) { border-color: var(--navy); }
+
+.alert {
+  border-radius: 10px;
+  padding: 0.75rem 1rem;
+  font-size: 0.9rem;
+  margin-bottom: 0.85rem;
+}
+.alert--error {
+  background: #FEF2F2;
+  color: var(--danger);
+  border: 1.5px solid #FECACA;
+}
+
+/* ───────── Mobile tweaks ───────── */
+@media (max-width: 480px) {
+  .survey { padding: 0.5rem; }
+  .state, .survey__form { padding-left: 1rem; padding-right: 1rem; }
+  .section__nav { flex-direction: column-reverse; }
+}

--- a/public/pesquisa/pesquisa.js
+++ b/public/pesquisa/pesquisa.js
@@ -1,0 +1,200 @@
+// Genius Idiomas — student survey page.
+// Server serves the same HTML for /pesquisa, /pesquisa/:token and (via
+// 302) /p/:token, so this script reads the token from the URL itself.
+
+(() => {
+  'use strict';
+
+  const MES_NOMBRE = {
+    1: 'enero', 2: 'febrero', 3: 'marzo', 4: 'abril', 5: 'mayo', 6: 'junio',
+    7: 'julio', 8: 'agosto', 9: 'septiembre', 10: 'octubre', 11: 'noviembre', 12: 'diciembre',
+  };
+
+  const states = {
+    loading: document.getElementById('state-loading'),
+    error:   document.getElementById('state-error'),
+    intro:   document.getElementById('state-intro'),
+    form:    document.getElementById('state-form'),
+    thanks:  document.getElementById('state-thanks'),
+  };
+  const errorMsg = document.getElementById('errorMsg');
+  const turmaName = document.getElementById('turmaName');
+  const profName = document.getElementById('profName');
+  const periodLabel = document.getElementById('periodLabel');
+  const progressBar = document.getElementById('progressBar');
+  const submitBtn = document.getElementById('submitBtn');
+  const submitError = document.getElementById('submitError');
+  const form = document.getElementById('surveyForm');
+
+  function show(name) {
+    for (const k of Object.keys(states)) {
+      states[k].classList.toggle('hidden', k !== name);
+    }
+  }
+
+  // ─── Token extraction ───
+  function extractToken() {
+    const m = window.location.pathname.match(/\/(?:pesquisa|p)\/([a-z0-9]+)/i);
+    return m ? m[1] : null;
+  }
+
+  // ─── Rating widget ───
+  function buildRatings() {
+    document.querySelectorAll('.rating').forEach((container) => {
+      const hidden = container.parentElement.querySelector('input[type="hidden"]');
+      for (let i = 1; i <= 5; i++) {
+        const btn = document.createElement('button');
+        btn.type = 'button';
+        btn.className = 'rating__btn';
+        btn.role = 'radio';
+        btn.setAttribute('aria-checked', 'false');
+        btn.dataset.value = String(i);
+        btn.textContent = String(i);
+        btn.addEventListener('click', () => {
+          container.querySelectorAll('.rating__btn').forEach((b) =>
+            b.setAttribute('aria-checked', 'false'),
+          );
+          btn.setAttribute('aria-checked', 'true');
+          hidden.value = String(i);
+        });
+        container.appendChild(btn);
+      }
+    });
+  }
+
+  // ─── Section navigation ───
+  let currentSection = 1;
+  const totalSections = document.querySelectorAll('.section').length;
+
+  function showSection(n) {
+    document.querySelectorAll('.section').forEach((s) => {
+      s.classList.toggle('hidden', Number(s.dataset.section) !== n);
+    });
+    currentSection = n;
+    progressBar.style.width = ((n - 1) / (totalSections - 1)) * 100 + '%';
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  }
+
+  function validateSection(n) {
+    const section = document.querySelector(`.section[data-section="${n}"]`);
+    const required = section.querySelectorAll('input[required]');
+    for (const inp of required) {
+      if (!inp.value) {
+        const q = inp.closest('.q');
+        if (q) q.scrollIntoView({ behavior: 'smooth', block: 'center' });
+        return false;
+      }
+    }
+    // Radio groups: check at least one checked per group with required.
+    const radioGroups = new Set();
+    section.querySelectorAll('input[type="radio"][required]').forEach((r) =>
+      radioGroups.add(r.name),
+    );
+    for (const name of radioGroups) {
+      const checked = section.querySelector(`input[name="${name}"]:checked`);
+      if (!checked) {
+        const group = section.querySelector(`.opts[data-name="${name}"]`);
+        if (group) group.scrollIntoView({ behavior: 'smooth', block: 'center' });
+        return false;
+      }
+    }
+    return true;
+  }
+
+  document.addEventListener('click', (ev) => {
+    const target = ev.target.closest('[data-next], [data-prev]');
+    if (!target) return;
+    if (target.dataset.next !== undefined) {
+      if (validateSection(currentSection)) showSection(currentSection + 1);
+    } else {
+      showSection(currentSection - 1);
+    }
+  });
+
+  // ─── Submit ───
+  async function submit(token) {
+    submitError.classList.add('hidden');
+    submitBtn.disabled = true;
+
+    const data = Object.fromEntries(new FormData(form).entries());
+    // FormData turns hidden inputs into strings; coerce numbers for the
+    // server-side IsInt validators.
+    data.nota_aulas = Number(data.nota_aulas);
+    data.nota_professor = Number(data.nota_professor);
+    data.nota_geral = Number(data.nota_geral);
+    // Drop empty optional fields rather than sending "".
+    for (const k of ['feedback_conteudo', 'feedback_professor', 'feedback_escola', 'situacao_pessoal']) {
+      if (data[k] === '') delete data[k];
+    }
+
+    try {
+      const resp = await fetch(`/api/pesquisa/${encodeURIComponent(token)}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data),
+      });
+      if (resp.status === 201 || resp.status === 200) {
+        show('thanks');
+        return;
+      }
+      const body = await resp.json().catch(() => ({}));
+      const msg = Array.isArray(body.message)
+        ? body.message.join(' · ')
+        : body.message || 'No pudimos enviar tu respuesta. Intenta nuevamente.';
+      submitError.textContent = msg;
+      submitError.classList.remove('hidden');
+    } catch (err) {
+      submitError.textContent = 'Error de conexión. Verifica tu internet.';
+      submitError.classList.remove('hidden');
+    } finally {
+      submitBtn.disabled = false;
+    }
+  }
+
+  // ─── Boot ───
+  async function boot() {
+    buildRatings();
+
+    const token = extractToken();
+    if (!token) {
+      show('intro');
+      return;
+    }
+
+    try {
+      const resp = await fetch(`/api/pesquisa/${encodeURIComponent(token)}/info`);
+      if (resp.status === 404) {
+        errorMsg.textContent = 'Este enlace no es válido.';
+        show('error');
+        return;
+      }
+      if (resp.status === 410) {
+        const body = await resp.json().catch(() => ({}));
+        errorMsg.textContent = body.message || 'Esta encuesta ya no está disponible.';
+        show('error');
+        return;
+      }
+      if (!resp.ok) throw new Error(`status ${resp.status}`);
+
+      const info = await resp.json();
+      turmaName.textContent = info.turma_nome || '—';
+      profName.textContent = info.professor_nome || '—';
+      const mes = MES_NOMBRE[info.mes_referencia] || info.mes_referencia;
+      periodLabel.textContent = `Encuesta de ${mes} ${info.ano_referencia}`;
+
+      show('form');
+      showSection(1);
+
+      form.addEventListener('submit', (ev) => {
+        ev.preventDefault();
+        if (!validateSection(currentSection)) return;
+        submit(token);
+      });
+    } catch (err) {
+      errorMsg.textContent = 'No pudimos cargar la encuesta. Intenta más tarde.';
+      show('error');
+    }
+  }
+
+  document.addEventListener('DOMContentLoaded', boot);
+})();

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -12,6 +12,11 @@ import { HealthController } from './health/health.controller';
 import { LeadsModule } from './leads/leads.module';
 import { TrackingEntryEntity } from './q10/tracking-entry.entity';
 import { Q10Module } from './q10/q10.module';
+import { SurveyAlert } from './survey/entities/survey-alert.entity';
+import { SurveyPeriod } from './survey/entities/survey-period.entity';
+import { SurveyResponse } from './survey/entities/survey-response.entity';
+import { SurveyToken } from './survey/entities/survey-token.entity';
+import { SurveyModule } from './survey/survey.module';
 
 const bootstrapLogger = new Logger('AppModule');
 
@@ -44,7 +49,14 @@ const bootstrapLogger = new Logger('AppModule');
         return {
           type: 'better-sqlite3',
           database: cfg.get<string>('DATABASE_PATH') ?? './data/genius.sqlite',
-          entities: [User, TrackingEntryEntity],
+          entities: [
+            User,
+            TrackingEntryEntity,
+            SurveyPeriod,
+            SurveyToken,
+            SurveyResponse,
+            SurveyAlert,
+          ],
           synchronize: true,
         };
       },
@@ -60,6 +72,7 @@ const bootstrapLogger = new Logger('AppModule');
     Q10Module,
     LeadsModule,
     EmailModule,
+    SurveyModule,
   ],
   controllers: [HealthController],
   providers: [

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import { ValidationPipe } from '@nestjs/common';
+import { RequestMethod, ValidationPipe } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
 import cookieParser = require('cookie-parser');
 import { mkdirSync } from 'fs';
@@ -84,7 +84,16 @@ async function bootstrap() {
     }),
   );
 
-  app.setGlobalPrefix('api', { exclude: [] });
+  // Survey HTML pages live outside /api so the URLs are short enough to
+  // share over WhatsApp (`/p/:token`, `/pesquisa/:token`). The matching AJAX
+  // endpoints stay under /api/pesquisa/:token.
+  app.setGlobalPrefix('api', {
+    exclude: [
+      { path: 'pesquisa', method: RequestMethod.GET },
+      { path: 'pesquisa/:token', method: RequestMethod.GET },
+      { path: 'p/:token', method: RequestMethod.GET },
+    ],
+  });
 
   const port = process.env.PORT || 3120;
   const host = process.env.HOST || '0.0.0.0';

--- a/src/survey/admin-survey.controller.ts
+++ b/src/survey/admin-survey.controller.ts
@@ -1,0 +1,53 @@
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  Post,
+  Req,
+  UseGuards,
+} from '@nestjs/common';
+import type { Request } from 'express';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { CreatePeriodDto } from './dto/create-period.dto';
+import { SurveyAnalyticsService } from './analytics.service';
+import { SurveyPeriodService } from './period.service';
+
+@Controller('admin/pesquisas')
+@UseGuards(JwtAuthGuard)
+export class AdminSurveyController {
+  constructor(
+    private readonly periods: SurveyPeriodService,
+    private readonly analytics: SurveyAnalyticsService,
+  ) {}
+
+  @Post('gerar')
+  async gerar(@Body() dto: CreatePeriodDto, @Req() req: Request) {
+    const user = (req as any).user;
+    const criadoPor = user?.name ?? user?.email ?? 'unknown';
+    return this.periods.createPeriod(dto, criadoPor);
+  }
+
+  @Get()
+  async list() {
+    return this.periods.listPeriods();
+  }
+
+  @Get(':id')
+  async detail(@Param('id') id: string) {
+    return this.analytics.periodDetail(id);
+  }
+
+  @Get(':id/turma/:turmaId')
+  async turma(
+    @Param('id') id: string,
+    @Param('turmaId') turmaId: string,
+  ) {
+    return this.analytics.turmaDetail(id, turmaId);
+  }
+
+  @Get(':id/mensagens-whatsapp')
+  async whatsapp(@Param('id') id: string) {
+    return this.analytics.whatsappMessages(id);
+  }
+}

--- a/src/survey/analytics.service.ts
+++ b/src/survey/analytics.service.ts
@@ -124,9 +124,17 @@ export class SurveyAnalyticsService {
   }
 
   /**
-   * WhatsApp messages, ready-to-paste, one per class. URL prefix is taken
-   * from PUBLIC_BASE_URL env var; falls back to a relative `/p/:token`,
-   * which the operator can prepend manually.
+   * Per-student WhatsApp messages, grouped by class for navigation but
+   * **never aggregated into a single block** — each `mensagem` contains
+   * exactly one token. The operator copies one message at a time into a
+   * 1-on-1 chat with the student.
+   *
+   * Why per-student: the token is the auth credential for the public POST
+   * endpoint, so any link visible to a third party can be consumed by
+   * them, locking out the legitimate student. A single "paste this in the
+   * group chat" block would expose every token to every classmate
+   * (review #17 finding). URL prefix is taken from PUBLIC_BASE_URL env;
+   * falls back to a relative `/p/:token`.
    */
   async whatsappMessages(period_id: string) {
     const period = await this.periods.findOne({ where: { id: period_id } });
@@ -136,7 +144,8 @@ export class SurveyAnalyticsService {
     const baseUrl = (this.config.get<string>('PUBLIC_BASE_URL') ?? '').replace(/\/+$/, '');
     const monthName = MES_PT[period.mes_referencia] ?? `${period.mes_referencia}`;
 
-    // Group by turma.
+    // Group by turma so the UI can show class context, but each entry's
+    // `mensagem` is for that single student — never the whole class.
     const byTurma = new Map<string, typeof tokens>();
     for (const t of tokens) {
       const arr = byTurma.get(t.turma_codigo) ?? [];
@@ -146,22 +155,27 @@ export class SurveyAnalyticsService {
 
     const turmas = [...byTurma.entries()].map(([turma_codigo, list]) => {
       const sample = list[0];
-      const lines = list
+      const alunos = list
         .slice()
         .sort((a, b) => a.aluno_nome.localeCompare(b.aluno_nome))
         .map((t) => {
           const url = baseUrl ? `${baseUrl}/p/${t.token}` : `/p/${t.token}`;
-          return `${t.aluno_nome} → ${url}`;
+          const firstName = t.aluno_nome.split(/\s+/)[0] || t.aluno_nome;
+          return {
+            aluno_codigo: t.aluno_codigo,
+            aluno_nome: t.aluno_nome,
+            mensagem:
+              `¡Hola ${firstName}! Tu encuesta de ${monthName} está aquí 🌟\n` +
+              `${url}\n\n` +
+              `Responder lleva menos de 3 minutos. ¡Gracias!`,
+          };
         });
-      const mensagem =
-        `¡Hola a todos! Encuesta de ${monthName} 🌟 ` +
-        `Cada uno tiene su link personal:\n${lines.join('\n')}`;
       return {
         turma_codigo,
         turma_nome: sample.turma_nome,
         professor_nome: sample.professor_nome,
         alunos_count: list.length,
-        mensagem,
+        alunos,
       };
     });
 

--- a/src/survey/analytics.service.ts
+++ b/src/survey/analytics.service.ts
@@ -1,0 +1,282 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { ConfigService } from '@nestjs/config';
+import { SurveyAlert } from './entities/survey-alert.entity';
+import { SurveyPeriod } from './entities/survey-period.entity';
+import { SurveyResponse } from './entities/survey-response.entity';
+import { SurveyToken } from './entities/survey-token.entity';
+import {
+  INTENCAO_CONTINUAR,
+  RECOMENDACAO_DETRACTORS,
+  RECOMENDACAO_PROMOTORS,
+} from './survey.constants';
+
+export interface TurmaStats {
+  turma_codigo: string;
+  turma_nome: string;
+  professor_nome: string | null;
+  alunos_count: number;
+  respondidas: number;
+  media_aulas: number | null;
+  media_professor: number | null;
+  media_geral: number | null;
+}
+
+@Injectable()
+export class SurveyAnalyticsService {
+  constructor(
+    @InjectRepository(SurveyPeriod)
+    private readonly periods: Repository<SurveyPeriod>,
+    @InjectRepository(SurveyToken)
+    private readonly tokens: Repository<SurveyToken>,
+    @InjectRepository(SurveyResponse)
+    private readonly responses: Repository<SurveyResponse>,
+    @InjectRepository(SurveyAlert)
+    private readonly alerts: Repository<SurveyAlert>,
+    private readonly config: ConfigService,
+  ) {}
+
+  /** Aggregate stats for one period. */
+  async periodDetail(period_id: string) {
+    const period = await this.periods.findOne({ where: { id: period_id } });
+    if (!period) throw new NotFoundException('Período no encontrado');
+
+    const [tokens, responses, alerts] = await Promise.all([
+      this.tokens.find({ where: { period_id } }),
+      this.responses.find({ where: { period_id } }),
+      this.alerts.find({
+        where: { period_id },
+        order: { criado_em: 'DESC' },
+      }),
+    ]);
+
+    return {
+      period: {
+        id: period.id,
+        mes_referencia: period.mes_referencia,
+        ano_referencia: period.ano_referencia,
+        criado_em: period.criado_em,
+        gerado_por: period.gerado_por,
+      },
+      summary: this.summarise(tokens, responses),
+      por_turma: this.statsPerTurma(tokens, responses),
+      alertas: alerts.map((a) => ({
+        id: a.id,
+        tipo: a.tipo,
+        detalhe: a.detalhe,
+        turma_codigo: a.turma_codigo,
+        criado_em: a.criado_em,
+        visualizado: a.visualizado,
+      })),
+    };
+  }
+
+  /** Responses for one specific class (anonymised — only the answers). */
+  async turmaDetail(period_id: string, turma_codigo: string) {
+    const period = await this.periods.findOne({ where: { id: period_id } });
+    if (!period) throw new NotFoundException('Período no encontrado');
+
+    const [tokens, responses] = await Promise.all([
+      this.tokens.find({ where: { period_id, turma_codigo } }),
+      this.responses.find({
+        where: { period_id, turma_codigo },
+        order: { respondido_em: 'DESC' },
+      }),
+    ]);
+    if (tokens.length === 0) throw new NotFoundException('Turma sin tokens en este período');
+
+    const sample = tokens[0];
+    return {
+      period: {
+        id: period.id,
+        mes_referencia: period.mes_referencia,
+        ano_referencia: period.ano_referencia,
+      },
+      turma: {
+        turma_codigo,
+        turma_nome: sample.turma_nome,
+        professor_nome: sample.professor_nome,
+      },
+      alunos_count: tokens.length,
+      respondidas: tokens.filter((t) => t.usado_em).length,
+      respostas: responses.map((r) => ({
+        id: r.id,
+        respondido_em: r.respondido_em,
+        nota_aulas: r.nota_aulas,
+        nota_professor: r.nota_professor,
+        nota_geral: r.nota_geral,
+        progresso: r.progresso,
+        ritmo: r.ritmo,
+        pontualidade: r.pontualidade,
+        tarefas: r.tarefas,
+        professor_explica: r.professor_explica,
+        aulas_dinamicas: r.aulas_dinamicas,
+        recomendacao: r.recomendacao,
+        atendimento: r.atendimento,
+        intencao_continuar: r.intencao_continuar,
+        feedback_conteudo: r.feedback_conteudo,
+        feedback_professor: r.feedback_professor,
+        feedback_escola: r.feedback_escola,
+        situacao_pessoal: r.situacao_pessoal,
+      })),
+    };
+  }
+
+  /**
+   * WhatsApp messages, ready-to-paste, one per class. URL prefix is taken
+   * from PUBLIC_BASE_URL env var; falls back to a relative `/p/:token`,
+   * which the operator can prepend manually.
+   */
+  async whatsappMessages(period_id: string) {
+    const period = await this.periods.findOne({ where: { id: period_id } });
+    if (!period) throw new NotFoundException('Período no encontrado');
+
+    const tokens = await this.tokens.find({ where: { period_id } });
+    const baseUrl = (this.config.get<string>('PUBLIC_BASE_URL') ?? '').replace(/\/+$/, '');
+    const monthName = MES_PT[period.mes_referencia] ?? `${period.mes_referencia}`;
+
+    // Group by turma.
+    const byTurma = new Map<string, typeof tokens>();
+    for (const t of tokens) {
+      const arr = byTurma.get(t.turma_codigo) ?? [];
+      arr.push(t);
+      byTurma.set(t.turma_codigo, arr);
+    }
+
+    const turmas = [...byTurma.entries()].map(([turma_codigo, list]) => {
+      const sample = list[0];
+      const lines = list
+        .slice()
+        .sort((a, b) => a.aluno_nome.localeCompare(b.aluno_nome))
+        .map((t) => {
+          const url = baseUrl ? `${baseUrl}/p/${t.token}` : `/p/${t.token}`;
+          return `${t.aluno_nome} → ${url}`;
+        });
+      const mensagem =
+        `¡Hola a todos! Encuesta de ${monthName} 🌟 ` +
+        `Cada uno tiene su link personal:\n${lines.join('\n')}`;
+      return {
+        turma_codigo,
+        turma_nome: sample.turma_nome,
+        professor_nome: sample.professor_nome,
+        alunos_count: list.length,
+        mensagem,
+      };
+    });
+
+    turmas.sort((a, b) => a.turma_nome.localeCompare(b.turma_nome));
+
+    return {
+      period: {
+        mes: period.mes_referencia,
+        ano: period.ano_referencia,
+      },
+      turmas,
+    };
+  }
+
+  // ─── helpers ───
+
+  private summarise(tokens: SurveyToken[], responses: SurveyResponse[]) {
+    const tokens_total = tokens.length;
+    const respondidas = responses.length;
+    const taxa_resposta =
+      tokens_total > 0 ? Math.round((respondidas / tokens_total) * 1000) / 10 : 0;
+
+    const media_aulas = avg(responses.map((r) => r.nota_aulas));
+    const media_professor = avg(responses.map((r) => r.nota_professor));
+    const media_geral = avg(responses.map((r) => r.nota_geral));
+
+    // NPS-style: %promotores − %detratores.
+    let promotores = 0;
+    let detratores = 0;
+    for (const r of responses) {
+      if ((RECOMENDACAO_PROMOTORS as readonly string[]).includes(r.recomendacao)) {
+        promotores++;
+      } else if ((RECOMENDACAO_DETRACTORS as readonly string[]).includes(r.recomendacao)) {
+        detratores++;
+      }
+    }
+    const nps =
+      respondidas > 0
+        ? Math.round(((promotores - detratores) / respondidas) * 100)
+        : null;
+
+    const intencao_distribuicao: Record<string, number> = {};
+    for (const v of INTENCAO_CONTINUAR) intencao_distribuicao[v] = 0;
+    for (const r of responses) {
+      if (r.intencao_continuar in intencao_distribuicao) {
+        intencao_distribuicao[r.intencao_continuar]++;
+      }
+    }
+
+    return {
+      tokens_total,
+      respondidas,
+      taxa_resposta,
+      media_aulas,
+      media_professor,
+      media_geral,
+      nps,
+      intencao_distribuicao,
+    };
+  }
+
+  private statsPerTurma(
+    tokens: SurveyToken[],
+    responses: SurveyResponse[],
+  ): TurmaStats[] {
+    const byCodigo = new Map<string, {
+      sample: SurveyToken;
+      tokens: SurveyToken[];
+      responses: SurveyResponse[];
+    }>();
+    for (const t of tokens) {
+      const entry = byCodigo.get(t.turma_codigo) ?? {
+        sample: t,
+        tokens: [],
+        responses: [],
+      };
+      entry.tokens.push(t);
+      byCodigo.set(t.turma_codigo, entry);
+    }
+    for (const r of responses) {
+      const entry = byCodigo.get(r.turma_codigo);
+      if (entry) entry.responses.push(r);
+    }
+    return [...byCodigo.values()]
+      .map(({ sample, tokens, responses }) => ({
+        turma_codigo: sample.turma_codigo,
+        turma_nome: sample.turma_nome,
+        professor_nome: sample.professor_nome,
+        alunos_count: tokens.length,
+        respondidas: responses.length,
+        media_aulas: avg(responses.map((r) => r.nota_aulas)),
+        media_professor: avg(responses.map((r) => r.nota_professor)),
+        media_geral: avg(responses.map((r) => r.nota_geral)),
+      }))
+      .sort((a, b) => a.turma_nome.localeCompare(b.turma_nome));
+  }
+}
+
+function avg(xs: number[]): number | null {
+  if (xs.length === 0) return null;
+  const sum = xs.reduce((a, b) => a + b, 0);
+  return Math.round((sum / xs.length) * 10) / 10;
+}
+
+const MES_PT: Record<number, string> = {
+  1: 'enero',
+  2: 'febrero',
+  3: 'marzo',
+  4: 'abril',
+  5: 'mayo',
+  6: 'junio',
+  7: 'julio',
+  8: 'agosto',
+  9: 'septiembre',
+  10: 'octubre',
+  11: 'noviembre',
+  12: 'diciembre',
+};

--- a/src/survey/dto/create-period.dto.ts
+++ b/src/survey/dto/create-period.dto.ts
@@ -1,0 +1,19 @@
+import { IsInt, Max, Min, IsOptional } from 'class-validator';
+
+export class CreatePeriodDto {
+  @IsInt()
+  @Min(1)
+  @Max(12)
+  mes: number;
+
+  @IsInt()
+  @Min(2025)
+  @Max(2100)
+  ano: number;
+
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  @Max(30)
+  validade_dias?: number;
+}

--- a/src/survey/dto/submit-response.dto.ts
+++ b/src/survey/dto/submit-response.dto.ts
@@ -1,0 +1,78 @@
+import {
+  IsIn,
+  IsInt,
+  IsOptional,
+  IsString,
+  Max,
+  MaxLength,
+  Min,
+} from 'class-validator';
+import {
+  ATENDIMENTO,
+  AULAS_DINAMICAS,
+  INTENCAO_CONTINUAR,
+  PONTUALIDADE,
+  PROFESSOR_EXPLICA,
+  PROGRESSO,
+  RECOMENDACAO,
+  RITMO,
+  TAREFAS,
+} from '../survey.constants';
+
+export class SubmitResponseDto {
+  @IsInt() @Min(1) @Max(5)
+  nota_aulas: number;
+
+  @IsIn(PROGRESSO as readonly string[])
+  progresso: string;
+
+  @IsIn(RITMO as readonly string[])
+  ritmo: string;
+
+  @IsIn(PONTUALIDADE as readonly string[])
+  pontualidade: string;
+
+  @IsIn(TAREFAS as readonly string[])
+  tarefas: string;
+
+  @IsInt() @Min(1) @Max(5)
+  nota_professor: number;
+
+  @IsIn(PROFESSOR_EXPLICA as readonly string[])
+  professor_explica: string;
+
+  @IsIn(AULAS_DINAMICAS as readonly string[])
+  aulas_dinamicas: string;
+
+  @IsInt() @Min(1) @Max(5)
+  nota_geral: number;
+
+  @IsIn(RECOMENDACAO as readonly string[])
+  recomendacao: string;
+
+  @IsIn(ATENDIMENTO as readonly string[])
+  atendimento: string;
+
+  @IsIn(INTENCAO_CONTINUAR as readonly string[])
+  intencao_continuar: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(2000)
+  feedback_conteudo?: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(2000)
+  feedback_professor?: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(2000)
+  feedback_escola?: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(2000)
+  situacao_pessoal?: string;
+}

--- a/src/survey/entities/survey-alert.entity.ts
+++ b/src/survey/entities/survey-alert.entity.ts
@@ -1,0 +1,44 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+
+export type SurveyAlertType =
+  | 'intencao_critica'
+  | 'nota_professor_baixa'
+  | 'nota_aulas_baixa';
+
+// Lightweight log table — each row is one trigger that fired when a response
+// came in. Email/WhatsApp escalation is intentionally out of scope (spec §7);
+// for now we just persist so the admin panel can surface them.
+@Entity('survey_alerts')
+@Index(['period_id'])
+@Index(['turma_codigo'])
+export class SurveyAlert {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'uuid' })
+  period_id: string;
+
+  @Column({ type: 'uuid' })
+  response_id: string;
+
+  @Column({ type: 'varchar' })
+  turma_codigo: string;
+
+  @Column({ type: 'varchar' })
+  tipo: SurveyAlertType;
+
+  @Column({ type: 'varchar' })
+  detalhe: string;
+
+  @Column({ type: 'boolean', default: false })
+  visualizado: boolean;
+
+  @CreateDateColumn()
+  criado_em: Date;
+}

--- a/src/survey/entities/survey-period.entity.ts
+++ b/src/survey/entities/survey-period.entity.ts
@@ -1,0 +1,29 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+
+@Entity('survey_periods')
+@Index(['mes_referencia', 'ano_referencia'], { unique: true })
+export class SurveyPeriod {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'integer' })
+  mes_referencia: number;
+
+  @Column({ type: 'integer' })
+  ano_referencia: number;
+
+  @Column({ type: 'varchar' })
+  gerado_por: string;
+
+  @Column({ type: 'integer', default: 7 })
+  validade_dias: number;
+
+  @CreateDateColumn()
+  criado_em: Date;
+}

--- a/src/survey/entities/survey-response.entity.ts
+++ b/src/survey/entities/survey-response.entity.ts
@@ -1,0 +1,81 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+import { SurveyPeriod } from './survey-period.entity';
+
+// The actual answer. Deliberately has NO aluno_codigo column — the token
+// (in SurveyToken) is what identifies who responded, and once the response
+// is saved, the link from response → student is gone.
+@Entity('survey_responses')
+export class SurveyResponse {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'uuid' })
+  period_id: string;
+
+  @ManyToOne(() => SurveyPeriod, { onDelete: 'CASCADE' })
+  period: SurveyPeriod;
+
+  @Column({ type: 'varchar' })
+  turma_codigo: string;
+
+  @CreateDateColumn()
+  respondido_em: Date;
+
+  // ─── Aulas ───
+  @Column({ type: 'integer' })
+  nota_aulas: number;
+
+  @Column({ type: 'varchar' })
+  progresso: string;
+
+  @Column({ type: 'varchar' })
+  ritmo: string;
+
+  @Column({ type: 'varchar' })
+  pontualidade: string;
+
+  @Column({ type: 'varchar' })
+  tarefas: string;
+
+  // ─── Professor ───
+  @Column({ type: 'integer' })
+  nota_professor: number;
+
+  @Column({ type: 'varchar' })
+  professor_explica: string;
+
+  @Column({ type: 'varchar' })
+  aulas_dinamicas: string;
+
+  // ─── Escola / experiência geral ───
+  @Column({ type: 'integer' })
+  nota_geral: number;
+
+  @Column({ type: 'varchar' })
+  recomendacao: string;
+
+  @Column({ type: 'varchar' })
+  atendimento: string;
+
+  @Column({ type: 'varchar' })
+  intencao_continuar: string;
+
+  // ─── Feedback livre ───
+  @Column({ type: 'text', nullable: true })
+  feedback_conteudo: string | null;
+
+  @Column({ type: 'text', nullable: true })
+  feedback_professor: string | null;
+
+  @Column({ type: 'text', nullable: true })
+  feedback_escola: string | null;
+
+  @Column({ type: 'text', nullable: true })
+  situacao_pessoal: string | null;
+}

--- a/src/survey/entities/survey-response.entity.ts
+++ b/src/survey/entities/survey-response.entity.ts
@@ -2,6 +2,7 @@ import {
   Column,
   CreateDateColumn,
   Entity,
+  JoinColumn,
   ManyToOne,
   PrimaryGeneratedColumn,
 } from 'typeorm';
@@ -19,6 +20,7 @@ export class SurveyResponse {
   period_id: string;
 
   @ManyToOne(() => SurveyPeriod, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'period_id' })
   period: SurveyPeriod;
 
   @Column({ type: 'varchar' })

--- a/src/survey/entities/survey-token.entity.ts
+++ b/src/survey/entities/survey-token.entity.ts
@@ -3,6 +3,7 @@ import {
   CreateDateColumn,
   Entity,
   Index,
+  JoinColumn,
   ManyToOne,
   PrimaryGeneratedColumn,
 } from 'typeorm';
@@ -27,6 +28,7 @@ export class SurveyToken {
   period_id: string;
 
   @ManyToOne(() => SurveyPeriod, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'period_id' })
   period: SurveyPeriod;
 
   // Q10 identifiers — kept as plain strings because the local DB has no

--- a/src/survey/entities/survey-token.entity.ts
+++ b/src/survey/entities/survey-token.entity.ts
@@ -1,0 +1,60 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+import { SurveyPeriod } from './survey-period.entity';
+
+// One row per (period, student). Identifies *who* responded so the operator
+// can chase down stragglers — but the response itself is stored in
+// SurveyResponse without aluno_codigo, preserving anonymity by design.
+@Entity('survey_tokens')
+@Index(['period_id', 'aluno_codigo'])
+@Index(['period_id', 'turma_codigo'])
+export class SurveyToken {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  // 12-char alphanumeric, generated via crypto.randomBytes — short enough
+  // to fit comfortably inside a WhatsApp link.
+  @Column({ type: 'varchar', length: 12, unique: true })
+  token: string;
+
+  @Column({ type: 'uuid' })
+  period_id: string;
+
+  @ManyToOne(() => SurveyPeriod, { onDelete: 'CASCADE' })
+  period: SurveyPeriod;
+
+  // Q10 identifiers — kept as plain strings because the local DB has no
+  // students/classes table; Q10 is the source of truth for those.
+  @Column({ type: 'varchar' })
+  aluno_codigo: string;
+
+  // Denormalized for WhatsApp message generation and so the recorded
+  // attribution survives downstream changes in Q10 (student moved class,
+  // teacher swapped, etc.).
+  @Column({ type: 'varchar' })
+  aluno_nome: string;
+
+  @Column({ type: 'varchar' })
+  turma_codigo: string;
+
+  @Column({ type: 'varchar' })
+  turma_nome: string;
+
+  @Column({ type: 'varchar', nullable: true })
+  professor_nome: string | null;
+
+  @Column({ type: 'datetime', nullable: true })
+  usado_em: Date | null;
+
+  @Column({ type: 'datetime' })
+  expira_em: Date;
+
+  @CreateDateColumn()
+  criado_em: Date;
+}

--- a/src/survey/entities/survey-token.entity.ts
+++ b/src/survey/entities/survey-token.entity.ts
@@ -12,8 +12,12 @@ import { SurveyPeriod } from './survey-period.entity';
 // One row per (period, student). Identifies *who* responded so the operator
 // can chase down stragglers — but the response itself is stored in
 // SurveyResponse without aluno_codigo, preserving anonymity by design.
+//
+// (period_id, aluno_codigo) is unique: spec contract is "um link único por
+// aluno por mês". The DB enforces it; the service deduplicates the Q10
+// input before insert as defense in depth.
 @Entity('survey_tokens')
-@Index(['period_id', 'aluno_codigo'])
+@Index(['period_id', 'aluno_codigo'], { unique: true })
 @Index(['period_id', 'turma_codigo'])
 export class SurveyToken {
   @PrimaryGeneratedColumn('uuid')

--- a/src/survey/period.service.ts
+++ b/src/survey/period.service.ts
@@ -1,0 +1,144 @@
+import {
+  ConflictException,
+  Injectable,
+  Logger,
+  NotFoundException,
+} from '@nestjs/common';
+import { InjectDataSource, InjectRepository } from '@nestjs/typeorm';
+import { DataSource, Repository } from 'typeorm';
+import { CreatePeriodDto } from './dto/create-period.dto';
+import { SurveyPeriod } from './entities/survey-period.entity';
+import { SurveyToken } from './entities/survey-token.entity';
+import { StudentSourceService } from './student-source.service';
+import { generateToken } from './token-generator';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+@Injectable()
+export class SurveyPeriodService {
+  private readonly logger = new Logger(SurveyPeriodService.name);
+
+  constructor(
+    @InjectRepository(SurveyPeriod)
+    private readonly periods: Repository<SurveyPeriod>,
+    @InjectRepository(SurveyToken)
+    private readonly tokens: Repository<SurveyToken>,
+    @InjectDataSource() private readonly dataSource: DataSource,
+    private readonly studentSource: StudentSourceService,
+  ) {}
+
+  async createPeriod(dto: CreatePeriodDto, criadoPor: string) {
+    const existing = await this.periods.findOne({
+      where: { mes_referencia: dto.mes, ano_referencia: dto.ano },
+    });
+    if (existing) {
+      throw new ConflictException(
+        `Ya existe un período para ${dto.mes}/${dto.ano}`,
+      );
+    }
+
+    const students = await this.studentSource.fetchActiveStudentsForSurvey();
+    if (students.length === 0) {
+      throw new ConflictException(
+        'No hay estudiantes activos para generar la encuesta',
+      );
+    }
+
+    const validadeDias = dto.validade_dias ?? 7;
+    const agora = new Date();
+    const expiraEm = new Date(agora.getTime() + validadeDias * DAY_MS);
+
+    return this.dataSource.transaction(async (manager) => {
+      const period = manager.create(SurveyPeriod, {
+        mes_referencia: dto.mes,
+        ano_referencia: dto.ano,
+        gerado_por: criadoPor,
+        validade_dias: validadeDias,
+      });
+      await manager.save(period);
+
+      // Generate tokens with collision retry — 12 chars over a 28-char
+      // alphabet gives us 28^12 ≈ 2.3e17 possibilities, but since we'll have
+      // ~100 students per period, a unique-constraint retry is enough.
+      const tokens: SurveyToken[] = [];
+      const seen = new Set<string>();
+      for (const s of students) {
+        let value = generateToken();
+        while (seen.has(value)) value = generateToken();
+        seen.add(value);
+        tokens.push(
+          manager.create(SurveyToken, {
+            token: value,
+            period_id: period.id,
+            aluno_codigo: s.aluno_codigo,
+            aluno_nome: s.aluno_nome,
+            turma_codigo: s.turma_codigo,
+            turma_nome: s.turma_nome,
+            professor_nome: s.professor_nome,
+            expira_em: expiraEm,
+          }),
+        );
+      }
+
+      // chunk to avoid hitting SQLite's parameter limit on huge classes.
+      for (let i = 0; i < tokens.length; i += 100) {
+        await manager.save(tokens.slice(i, i + 100));
+      }
+
+      this.logger.log(
+        `Período ${dto.mes}/${dto.ano} criado com ${tokens.length} tokens (gerado_por=${criadoPor})`,
+      );
+
+      return {
+        period,
+        tokens_created: tokens.length,
+      };
+    });
+  }
+
+  async listPeriods() {
+    const all = await this.periods.find({
+      order: { ano_referencia: 'DESC', mes_referencia: 'DESC' },
+    });
+    if (all.length === 0) return [];
+
+    // Counts per period in one round-trip rather than N+1.
+    const ids = all.map((p) => p.id);
+    const tokenCounts = await this.tokens
+      .createQueryBuilder('t')
+      .select('t.period_id', 'period_id')
+      .addSelect('COUNT(*)', 'total')
+      .addSelect(
+        'SUM(CASE WHEN t.usado_em IS NOT NULL THEN 1 ELSE 0 END)',
+        'respondidas',
+      )
+      .where('t.period_id IN (:...ids)', { ids })
+      .groupBy('t.period_id')
+      .getRawMany();
+
+    const byPeriod = new Map<string, { total: number; respondidas: number }>();
+    for (const row of tokenCounts) {
+      byPeriod.set(row.period_id, {
+        total: Number(row.total) || 0,
+        respondidas: Number(row.respondidas) || 0,
+      });
+    }
+
+    return all.map((p) => ({
+      id: p.id,
+      mes_referencia: p.mes_referencia,
+      ano_referencia: p.ano_referencia,
+      gerado_por: p.gerado_por,
+      criado_em: p.criado_em,
+      validade_dias: p.validade_dias,
+      tokens_total: byPeriod.get(p.id)?.total ?? 0,
+      tokens_respondidos: byPeriod.get(p.id)?.respondidas ?? 0,
+    }));
+  }
+
+  async getPeriodOrFail(id: string): Promise<SurveyPeriod> {
+    const p = await this.periods.findOne({ where: { id } });
+    if (!p) throw new NotFoundException('Período no encontrado');
+    return p;
+  }
+}

--- a/src/survey/public-survey.controller.ts
+++ b/src/survey/public-survey.controller.ts
@@ -1,0 +1,34 @@
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  Post,
+} from '@nestjs/common';
+import { Throttle } from '@nestjs/throttler';
+import { SubmitResponseDto } from './dto/submit-response.dto';
+import { SurveyResponseService } from './response.service';
+
+// AJAX endpoints called by the student-facing page. The HTML itself is
+// served by SurveyPagesController so it can sit outside the /api prefix.
+@Controller('pesquisa')
+export class PublicSurveyController {
+  constructor(private readonly responses: SurveyResponseService) {}
+
+  @Get(':token')
+  @Throttle({ default: { limit: 30, ttl: 3600_000 } })
+  async getSurvey(@Param('token') token: string) {
+    return this.responses.getSurveyByToken(token);
+  }
+
+  // 10 req/h per IP (spec §5). Defends against accidental double-submit and
+  // someone trying to brute-force token values from a single IP.
+  @Post(':token')
+  @Throttle({ default: { limit: 10, ttl: 3600_000 } })
+  async submit(
+    @Param('token') token: string,
+    @Body() dto: SubmitResponseDto,
+  ) {
+    return this.responses.submitResponse(token, dto);
+  }
+}

--- a/src/survey/public-survey.controller.ts
+++ b/src/survey/public-survey.controller.ts
@@ -10,12 +10,15 @@ import { SubmitResponseDto } from './dto/submit-response.dto';
 import { SurveyResponseService } from './response.service';
 
 // AJAX endpoints called by the student-facing page. The HTML itself is
-// served by SurveyPagesController so it can sit outside the /api prefix.
+// served by SurveyPagesController and lives at /pesquisa/:token (outside
+// the /api prefix). To keep the global-prefix exclusion targeted to the
+// HTML route only, the AJAX context fetch uses `:token/info` so its full
+// path stays under /api.
 @Controller('pesquisa')
 export class PublicSurveyController {
   constructor(private readonly responses: SurveyResponseService) {}
 
-  @Get(':token')
+  @Get(':token/info')
   @Throttle({ default: { limit: 30, ttl: 3600_000 } })
   async getSurvey(@Param('token') token: string) {
     return this.responses.getSurveyByToken(token);

--- a/src/survey/response.service.ts
+++ b/src/survey/response.service.ts
@@ -1,0 +1,136 @@
+import {
+  GoneException,
+  Injectable,
+  Logger,
+  NotFoundException,
+} from '@nestjs/common';
+import { InjectDataSource, InjectRepository } from '@nestjs/typeorm';
+import { DataSource, Repository } from 'typeorm';
+import { SubmitResponseDto } from './dto/submit-response.dto';
+import { SurveyAlert, SurveyAlertType } from './entities/survey-alert.entity';
+import { SurveyResponse } from './entities/survey-response.entity';
+import { SurveyToken } from './entities/survey-token.entity';
+import {
+  INTENCAO_CRITICA,
+  NOTA_BAIXA_THRESHOLD,
+} from './survey.constants';
+
+@Injectable()
+export class SurveyResponseService {
+  private readonly logger = new Logger(SurveyResponseService.name);
+
+  constructor(
+    @InjectRepository(SurveyToken)
+    private readonly tokens: Repository<SurveyToken>,
+    @InjectDataSource() private readonly dataSource: DataSource,
+  ) {}
+
+  /** Read-only validation used by the public page before showing the form. */
+  async getSurveyByToken(token: string) {
+    const t = await this.tokens.findOne({
+      where: { token },
+      relations: { period: true },
+    });
+    if (!t) throw new NotFoundException('Link inválido');
+    if (t.usado_em) throw new GoneException('Esta encuesta ya fue respondida');
+    if (new Date() > t.expira_em) {
+      throw new GoneException('Esta encuesta expiró');
+    }
+    return {
+      turma_nome: t.turma_nome,
+      professor_nome: t.professor_nome,
+      mes_referencia: t.period.mes_referencia,
+      ano_referencia: t.period.ano_referencia,
+    };
+  }
+
+  /**
+   * Submit transactionally: validate, persist response, atomically mark the
+   * token used (UPDATE … WHERE usado_em IS NULL), derive alerts. The atomic
+   * mark closes the TOCTOU race that two concurrent submissions on the same
+   * token would otherwise win — better-sqlite3 doesn't support pessimistic
+   * row locks, so we rely on SQL's UPDATE-with-predicate semantics, which
+   * are portable to Postgres if the project migrates.
+   */
+  async submitResponse(token: string, dto: SubmitResponseDto) {
+    return this.dataSource.transaction(async (manager) => {
+      const t = await manager.findOne(SurveyToken, { where: { token } });
+      if (!t) throw new NotFoundException('Link inválido');
+      if (t.usado_em) throw new GoneException('Esta encuesta ya fue respondida');
+      if (new Date() > t.expira_em) {
+        throw new GoneException('Esta encuesta expiró');
+      }
+
+      const response = manager.create(SurveyResponse, {
+        period_id: t.period_id,
+        turma_codigo: t.turma_codigo,
+        nota_aulas: dto.nota_aulas,
+        progresso: dto.progresso,
+        ritmo: dto.ritmo,
+        pontualidade: dto.pontualidade,
+        tarefas: dto.tarefas,
+        nota_professor: dto.nota_professor,
+        professor_explica: dto.professor_explica,
+        aulas_dinamicas: dto.aulas_dinamicas,
+        nota_geral: dto.nota_geral,
+        recomendacao: dto.recomendacao,
+        atendimento: dto.atendimento,
+        intencao_continuar: dto.intencao_continuar,
+        feedback_conteudo: dto.feedback_conteudo ?? null,
+        feedback_professor: dto.feedback_professor ?? null,
+        feedback_escola: dto.feedback_escola ?? null,
+        situacao_pessoal: dto.situacao_pessoal ?? null,
+      });
+      await manager.save(response);
+
+      const now = new Date();
+      const result = await manager
+        .createQueryBuilder()
+        .update(SurveyToken)
+        .set({ usado_em: now })
+        .where('id = :id AND usado_em IS NULL', { id: t.id })
+        .execute();
+      if (!result.affected || result.affected === 0) {
+        // Lost the race against a concurrent submission. Throwing rolls
+        // back the freshly-inserted response too.
+        throw new GoneException('Esta encuesta ya fue respondida');
+      }
+
+      const alerts = this.deriveAlerts(t.period_id, response.id, dto, t.turma_codigo);
+      if (alerts.length > 0) {
+        await manager.save(SurveyAlert, alerts);
+        this.logger.warn(
+          `Respuesta crítica registrada en período ${t.period_id}: ${alerts.map((a) => a.tipo).join(', ')}`,
+        );
+      }
+
+      return { success: true };
+    });
+  }
+
+  private deriveAlerts(
+    period_id: string,
+    response_id: string,
+    dto: SubmitResponseDto,
+    turma_codigo: string,
+  ): Partial<SurveyAlert>[] {
+    const alerts: Partial<SurveyAlert>[] = [];
+    const push = (tipo: SurveyAlertType, detalhe: string) =>
+      alerts.push({ period_id, response_id, turma_codigo, tipo, detalhe });
+
+    if (
+      INTENCAO_CRITICA.includes(
+        dto.intencao_continuar as (typeof INTENCAO_CRITICA)[number],
+      )
+    ) {
+      push('intencao_critica', `intencao_continuar=${dto.intencao_continuar}`);
+    }
+    if (dto.nota_professor <= NOTA_BAIXA_THRESHOLD) {
+      push('nota_professor_baixa', `nota_professor=${dto.nota_professor}`);
+    }
+    if (dto.nota_aulas <= NOTA_BAIXA_THRESHOLD) {
+      push('nota_aulas_baixa', `nota_aulas=${dto.nota_aulas}`);
+    }
+    return alerts;
+  }
+}

--- a/src/survey/student-source.service.ts
+++ b/src/survey/student-source.service.ts
@@ -1,0 +1,128 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Q10ClientService } from '../q10/q10-client.service';
+
+export interface StudentForSurvey {
+  aluno_codigo: string;
+  aluno_nome: string;
+  turma_codigo: string;
+  turma_nome: string;
+  professor_nome: string | null;
+}
+
+interface Q10Student {
+  Codigo_estudiante?: string;
+  Codigo?: string;
+  Id?: string;
+  Nombres?: string;
+  Apellidos?: string;
+  Codigo_programa?: string;
+  Estado?: string;
+  Activo?: string | boolean;
+}
+
+interface Q10Program {
+  Codigo?: string;
+  Id?: string;
+  Nombre?: string;
+}
+
+interface Q10Course {
+  Codigo_programa?: string;
+  Nombre_docente?: string;
+  Codigo_docente?: string;
+  Estado?: string;
+}
+
+const ACTIVE_STATES = new Set(['activo', 'activa', 'true', '1', 'active']);
+function isActiveStudent(s: Q10Student): boolean {
+  if (s.Activo === true) return true;
+  const flag = String(s.Activo ?? s.Estado ?? '').toLowerCase();
+  return ACTIVE_STATES.has(flag);
+}
+
+function studentId(s: Q10Student): string {
+  return String(s.Codigo_estudiante ?? s.Codigo ?? s.Id ?? '');
+}
+
+function fullName(s: Q10Student): string {
+  return [s.Nombres, s.Apellidos].filter(Boolean).join(' ').trim();
+}
+
+/**
+ * Resolves the list of students that should receive a survey for a given
+ * month, along with their class / teacher attribution.
+ *
+ * Note on the data model: Q10 (the source of truth) does not expose a clean
+ * student → course join in the endpoints we currently wrap. We therefore
+ * group students by `Codigo_programa` and treat the program as the "turma".
+ * Professor name is best-effort: we look at the courses in that program and
+ * pick the most-frequent teacher. When the operator needs finer granularity
+ * (e.g. per-section turmas), they'll need to adjust either Q10's data or
+ * this resolver — flagged in the PR description.
+ */
+@Injectable()
+export class StudentSourceService {
+  private readonly logger = new Logger(StudentSourceService.name);
+
+  constructor(private readonly q10: Q10ClientService) {}
+
+  async fetchActiveStudentsForSurvey(): Promise<StudentForSurvey[]> {
+    const [students, programs, courses] = await Promise.all([
+      this.q10.getAll<Q10Student>('/estudiantes').catch((err) => {
+        this.logger.error(`/estudiantes fetch failed: ${(err as Error).message}`);
+        throw err;
+      }),
+      this.q10.getAll<Q10Program>('/programas').catch(() => [] as Q10Program[]),
+      this.q10.getAll<Q10Course>('/cursos').catch(() => [] as Q10Course[]),
+    ]);
+
+    const programNameByCode = new Map<string, string>();
+    for (const p of programs) {
+      const code = String(p.Codigo ?? p.Id ?? '');
+      const name = String(p.Nombre ?? '').trim();
+      if (code && name) programNameByCode.set(code, name);
+    }
+
+    // Most-frequent teacher per program. We iterate `cursos`, count teacher
+    // occurrences inside each program, and pick the dominant one.
+    const teacherCounts = new Map<string, Map<string, number>>();
+    for (const c of courses) {
+      const prog = String(c.Codigo_programa ?? '');
+      const teacher = String(c.Nombre_docente ?? '').trim();
+      if (!prog || !teacher) continue;
+      const inner = teacherCounts.get(prog) ?? new Map<string, number>();
+      inner.set(teacher, (inner.get(teacher) ?? 0) + 1);
+      teacherCounts.set(prog, inner);
+    }
+    const dominantTeacherByProgram = new Map<string, string | null>();
+    for (const [prog, counts] of teacherCounts) {
+      let best: string | null = null;
+      let bestCount = 0;
+      for (const [name, n] of counts) {
+        if (n > bestCount) {
+          best = name;
+          bestCount = n;
+        }
+      }
+      dominantTeacherByProgram.set(prog, best);
+    }
+
+    const out: StudentForSurvey[] = [];
+    for (const s of students) {
+      if (!isActiveStudent(s)) continue;
+      const id = studentId(s);
+      if (!id) continue;
+      const turmaCodigo = String(s.Codigo_programa ?? '');
+      if (!turmaCodigo) continue;
+      out.push({
+        aluno_codigo: id,
+        aluno_nome: fullName(s) || id,
+        turma_codigo: turmaCodigo,
+        turma_nome: programNameByCode.get(turmaCodigo) ?? turmaCodigo,
+        professor_nome: dominantTeacherByProgram.get(turmaCodigo) ?? null,
+      });
+    }
+
+    return out;
+  }
+}

--- a/src/survey/student-source.service.ts
+++ b/src/survey/student-source.service.ts
@@ -107,13 +107,21 @@ export class StudentSourceService {
       dominantTeacherByProgram.set(prog, best);
     }
 
+    // Deduplicate by aluno_codigo: Q10 occasionally returns the same student
+    // twice (e.g. enrolled in two programs at the same time, or duplicate
+    // rows in the source table). The DB also has a unique constraint on
+    // (period_id, aluno_codigo), but catching it here gives a cleaner error
+    // and keeps the failure mode "we generated fewer tokens than expected"
+    // instead of "the whole transaction blew up halfway through."
+    const seen = new Set<string>();
     const out: StudentForSurvey[] = [];
     for (const s of students) {
       if (!isActiveStudent(s)) continue;
       const id = studentId(s);
-      if (!id) continue;
+      if (!id || seen.has(id)) continue;
       const turmaCodigo = String(s.Codigo_programa ?? '');
       if (!turmaCodigo) continue;
+      seen.add(id);
       out.push({
         aluno_codigo: id,
         aluno_nome: fullName(s) || id,

--- a/src/survey/survey-pages.controller.ts
+++ b/src/survey/survey-pages.controller.ts
@@ -1,0 +1,27 @@
+import { Controller, Get, Param, Res } from '@nestjs/common';
+import type { Response } from 'express';
+import { join } from 'path';
+
+const PUBLIC_DIR = join(__dirname, '..', '..', 'public');
+
+// HTML pages served outside the /api prefix. Routes here are listed in the
+// global-prefix exclusion in main.ts. The page HTML is identical for all
+// three routes — the client-side JS reads the token from the URL.
+@Controller()
+export class SurveyPagesController {
+  @Get('pesquisa')
+  intro(@Res() res: Response) {
+    res.sendFile(join(PUBLIC_DIR, 'pesquisa', 'index.html'));
+  }
+
+  @Get('pesquisa/:token')
+  withToken(@Res() res: Response) {
+    res.sendFile(join(PUBLIC_DIR, 'pesquisa', 'index.html'));
+  }
+
+  // Short alias so the WhatsApp message stays compact.
+  @Get('p/:token')
+  short(@Param('token') token: string, @Res() res: Response) {
+    res.redirect(302, `/pesquisa/${token}`);
+  }
+}

--- a/src/survey/survey.constants.ts
+++ b/src/survey/survey.constants.ts
@@ -1,0 +1,63 @@
+// Allowed values for each enum-like column. Centralised here so DTO
+// validators, analytics aggregations and the admin/public HTML stay in sync.
+
+export const PROGRESSO = ['mucho_progreso', 'un_poco', 'no_lo_noto', 'retrocediendo'] as const;
+export const RITMO = ['perfecto', 'un_poco_rapido', 'un_poco_lento', 'muy_rapido'] as const;
+export const PONTUALIDADE = [
+  'siempre',
+  'casi_siempre',
+  'a_veces_demoras',
+  'frecuentemente_demoras',
+] as const;
+export const TAREFAS = [
+  'bien',
+  'un_poco_faciles',
+  'un_poco_dificiles',
+  'muy_dificiles',
+  'no_hubo',
+  'mas_tareas',
+] as const;
+export const PROFESSOR_EXPLICA = [
+  'siempre',
+  'casi_siempre',
+  'a_veces_no',
+  'generalmente_no',
+] as const;
+export const AULAS_DINAMICAS = [
+  'siempre',
+  'casi_siempre',
+  'a_veces_monotonas',
+  'cuesta_atencion',
+] as const;
+export const RECOMENDACAO = [
+  'definitivamente',
+  'probablemente_si',
+  'no_seguro',
+  'probablemente_no',
+  'no_recomendaria',
+] as const;
+export const ATENDIMENTO = ['excelente', 'buena', 'regular', 'mala'] as const;
+export const INTENCAO_CONTINUAR = [
+  'comprometido',
+  'siguiendo',
+  'desmotivado',
+  'pensando_pausa',
+  'considerando_no_continuar',
+] as const;
+
+// Values that fire the "intenção crítica" alert (spec §4.1).
+export const INTENCAO_CRITICA: ReadonlyArray<(typeof INTENCAO_CONTINUAR)[number]> = [
+  'pensando_pausa',
+  'considerando_no_continuar',
+];
+
+// NPS-style scoring on `recomendacao` (spec §4.2).
+export const RECOMENDACAO_PROMOTORS: ReadonlyArray<(typeof RECOMENDACAO)[number]> = [
+  'definitivamente',
+  'probablemente_si',
+];
+export const RECOMENDACAO_DETRACTORS: ReadonlyArray<(typeof RECOMENDACAO)[number]> = [
+  'no_recomendaria',
+];
+
+export const NOTA_BAIXA_THRESHOLD = 2; // ≤ 2 dispara alerta

--- a/src/survey/survey.module.ts
+++ b/src/survey/survey.module.ts
@@ -1,0 +1,40 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { AuthModule } from '../auth/auth.module';
+import { Q10Module } from '../q10/q10.module';
+import { AdminSurveyController } from './admin-survey.controller';
+import { SurveyAnalyticsService } from './analytics.service';
+import { SurveyAlert } from './entities/survey-alert.entity';
+import { SurveyPeriod } from './entities/survey-period.entity';
+import { SurveyResponse } from './entities/survey-response.entity';
+import { SurveyToken } from './entities/survey-token.entity';
+import { SurveyPeriodService } from './period.service';
+import { PublicSurveyController } from './public-survey.controller';
+import { SurveyResponseService } from './response.service';
+import { StudentSourceService } from './student-source.service';
+import { SurveyPagesController } from './survey-pages.controller';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([
+      SurveyPeriod,
+      SurveyToken,
+      SurveyResponse,
+      SurveyAlert,
+    ]),
+    AuthModule,
+    Q10Module,
+  ],
+  controllers: [
+    AdminSurveyController,
+    PublicSurveyController,
+    SurveyPagesController,
+  ],
+  providers: [
+    SurveyPeriodService,
+    SurveyResponseService,
+    SurveyAnalyticsService,
+    StudentSourceService,
+  ],
+})
+export class SurveyModule {}

--- a/src/survey/token-generator.ts
+++ b/src/survey/token-generator.ts
@@ -1,0 +1,19 @@
+import { randomBytes } from 'crypto';
+
+// Excludes vowels and confusable chars (0/O/1/l/i) to keep tokens easy to
+// type if a student reads one off WhatsApp on a different device.
+const ALPHABET = '23456789bcdfghjkmnpqrstvwxyz';
+
+/** 12-char unguessable token (~57 bits of entropy). */
+export function generateToken(length = 12): string {
+  // randomBytes(length) gives us length bytes of entropy; we map each into
+  // ALPHABET via modulo. This biases very slightly toward earlier letters
+  // (256 mod 28 = 4 leftover) — at 12 chars that's negligible for our needs
+  // (we collision-check on insert anyway).
+  const bytes = randomBytes(length);
+  let out = '';
+  for (let i = 0; i < length; i++) {
+    out += ALPHABET[bytes[i] % ALPHABET.length];
+  }
+  return out;
+}

--- a/test/helpers/app.ts
+++ b/test/helpers/app.ts
@@ -1,4 +1,4 @@
-import { ValidationPipe, INestApplication } from '@nestjs/common';
+import { RequestMethod, ValidationPipe, INestApplication } from '@nestjs/common';
 import { Test } from '@nestjs/testing';
 import cookieParser = require('cookie-parser');
 import { AppModule } from '../../src/app.module';
@@ -17,7 +17,16 @@ export async function createTestApp(): Promise<INestApplication> {
       transform: true,
     }),
   );
-  app.setGlobalPrefix('api');
+  // Mirror main.ts: survey HTML routes live outside /api so the URLs stay
+  // short for WhatsApp. Keeping the test app aligned with prod prevents
+  // route collisions between SurveyPagesController and PublicSurveyController.
+  app.setGlobalPrefix('api', {
+    exclude: [
+      { path: 'pesquisa', method: RequestMethod.GET },
+      { path: 'pesquisa/:token', method: RequestMethod.GET },
+      { path: 'p/:token', method: RequestMethod.GET },
+    ],
+  });
   await app.init();
   return app;
 }

--- a/test/survey-alerts.spec.ts
+++ b/test/survey-alerts.spec.ts
@@ -1,0 +1,28 @@
+import {
+  INTENCAO_CRITICA,
+  NOTA_BAIXA_THRESHOLD,
+  RECOMENDACAO_DETRACTORS,
+  RECOMENDACAO_PROMOTORS,
+} from '../src/survey/survey.constants';
+
+// Pure-data assertions — guards against accidentally widening the alert
+// triggers without touching the spec.
+describe('survey alert thresholds', () => {
+  it('flags only the two critical "intenção" values', () => {
+    expect(INTENCAO_CRITICA).toEqual([
+      'pensando_pausa',
+      'considerando_no_continuar',
+    ]);
+  });
+
+  it('uses ≤2 as the "nota baixa" threshold', () => {
+    expect(NOTA_BAIXA_THRESHOLD).toBe(2);
+  });
+
+  it('NPS promoter / detractor sets are disjoint', () => {
+    const overlap = RECOMENDACAO_PROMOTORS.filter((v) =>
+      (RECOMENDACAO_DETRACTORS as readonly string[]).includes(v),
+    );
+    expect(overlap).toEqual([]);
+  });
+});

--- a/test/survey-student-source.spec.ts
+++ b/test/survey-student-source.spec.ts
@@ -1,0 +1,78 @@
+import { StudentSourceService } from '../src/survey/student-source.service';
+
+const makeQ10 = (responses: Record<string, any[]>) =>
+  ({
+    getAll: jest.fn(async (path: string) => responses[path] ?? []),
+  }) as any;
+
+describe('StudentSourceService.fetchActiveStudentsForSurvey', () => {
+  it('keeps only active students and emits one entry per aluno_codigo', async () => {
+    const q10 = makeQ10({
+      '/estudiantes': [
+        { Codigo_estudiante: 'EST-001', Nombres: 'Ana', Apellidos: 'García', Codigo_programa: 'P1', Estado: 'Activo' },
+        { Codigo_estudiante: 'EST-002', Nombres: 'Bruno', Apellidos: 'Cruz', Codigo_programa: 'P1', Estado: 'Activo' },
+        { Codigo_estudiante: 'EST-003', Nombres: 'Cesar', Apellidos: 'Diaz', Codigo_programa: 'P2', Estado: 'Inactivo' },
+      ],
+      '/programas': [
+        { Codigo: 'P1', Nombre: 'Inglés Básico' },
+        { Codigo: 'P2', Nombre: 'Inglés Avanzado' },
+      ],
+      '/cursos': [
+        { Codigo_programa: 'P1', Nombre_docente: 'Prof Ana' },
+        { Codigo_programa: 'P1', Nombre_docente: 'Prof Ana' },
+        { Codigo_programa: 'P1', Nombre_docente: 'Prof Beto' },
+      ],
+    });
+
+    const svc = new StudentSourceService(q10);
+    const out = await svc.fetchActiveStudentsForSurvey();
+
+    expect(out.map((s) => s.aluno_codigo)).toEqual(['EST-001', 'EST-002']);
+    expect(out[0]).toEqual({
+      aluno_codigo: 'EST-001',
+      aluno_nome: 'Ana García',
+      turma_codigo: 'P1',
+      turma_nome: 'Inglés Básico',
+      professor_nome: 'Prof Ana', // dominant teacher in P1 (2 vs 1 occurrences)
+    });
+  });
+
+  it('deduplicates a student that Q10 returns multiple times', async () => {
+    // Same student appears twice — once per program. The contract is one
+    // token per aluno per mês, so we keep the first occurrence and drop
+    // the rest. The DB-level unique constraint is the second line of
+    // defense if a refactor ever skips this dedup.
+    const q10 = makeQ10({
+      '/estudiantes': [
+        { Codigo_estudiante: 'EST-DUP', Nombres: 'Dup', Apellidos: 'A', Codigo_programa: 'P1', Estado: 'Activo' },
+        { Codigo_estudiante: 'EST-DUP', Nombres: 'Dup', Apellidos: 'A', Codigo_programa: 'P2', Estado: 'Activo' },
+        { Codigo_estudiante: 'EST-OTHER', Nombres: 'Other', Apellidos: 'B', Codigo_programa: 'P1', Estado: 'Activo' },
+      ],
+      '/programas': [],
+      '/cursos': [],
+    });
+
+    const svc = new StudentSourceService(q10);
+    const out = await svc.fetchActiveStudentsForSurvey();
+
+    expect(out.map((s) => s.aluno_codigo).sort()).toEqual(['EST-DUP', 'EST-OTHER']);
+    // Kept the first occurrence's program assignment.
+    expect(out.find((s) => s.aluno_codigo === 'EST-DUP')!.turma_codigo).toBe('P1');
+  });
+
+  it('skips students without an aluno_codigo or program', async () => {
+    const q10 = makeQ10({
+      '/estudiantes': [
+        { Nombres: 'Sin', Apellidos: 'Codigo', Codigo_programa: 'P1', Estado: 'Activo' },
+        { Codigo_estudiante: 'EST-X', Nombres: 'Sin', Apellidos: 'Programa', Estado: 'Activo' },
+        { Codigo_estudiante: 'EST-OK', Nombres: 'OK', Apellidos: 'Test', Codigo_programa: 'P1', Estado: 'Activo' },
+      ],
+      '/programas': [],
+      '/cursos': [],
+    });
+
+    const svc = new StudentSourceService(q10);
+    const out = await svc.fetchActiveStudentsForSurvey();
+    expect(out.map((s) => s.aluno_codigo)).toEqual(['EST-OK']);
+  });
+});

--- a/test/survey-token-generator.spec.ts
+++ b/test/survey-token-generator.spec.ts
@@ -1,0 +1,27 @@
+import { generateToken } from '../src/survey/token-generator';
+
+describe('generateToken', () => {
+  it('produces 12-char tokens by default', () => {
+    expect(generateToken()).toHaveLength(12);
+  });
+
+  it('respects a custom length', () => {
+    expect(generateToken(8)).toHaveLength(8);
+    expect(generateToken(20)).toHaveLength(20);
+  });
+
+  it('only emits letters and digits from the safe alphabet', () => {
+    // Excludes 0, 1, l, i, o, vowels — verifies our easy-to-type contract.
+    const safe = /^[23456789bcdfghjkmnpqrstvwxyz]+$/;
+    for (let i = 0; i < 50; i++) {
+      expect(generateToken()).toMatch(safe);
+    }
+  });
+
+  it('generates unique tokens with negligible collision rate', () => {
+    const tokens = new Set<string>();
+    for (let i = 0; i < 5000; i++) tokens.add(generateToken());
+    // 28^12 ≈ 2.3e17 — collisions in 5k draws are vanishingly unlikely.
+    expect(tokens.size).toBe(5000);
+  });
+});

--- a/test/survey.e2e-spec.ts
+++ b/test/survey.e2e-spec.ts
@@ -1,0 +1,253 @@
+import { INestApplication } from '@nestjs/common';
+import { DataSource } from 'typeorm';
+import request = require('supertest');
+import { SurveyResponse } from '../src/survey/entities/survey-response.entity';
+import { createTestApp, loginAsAdmin } from './helpers/app';
+
+const VALID_RESPONSE = {
+  nota_aulas: 5,
+  progresso: 'mucho_progreso',
+  ritmo: 'perfecto',
+  pontualidade: 'siempre',
+  tarefas: 'bien',
+  nota_professor: 5,
+  professor_explica: 'siempre',
+  aulas_dinamicas: 'siempre',
+  nota_geral: 5,
+  recomendacao: 'definitivamente',
+  atendimento: 'excelente',
+  intencao_continuar: 'comprometido',
+  feedback_conteudo: 'todo bien',
+};
+
+const CRITICAL_RESPONSE = {
+  ...VALID_RESPONSE,
+  nota_aulas: 1,
+  nota_professor: 2,
+  recomendacao: 'no_recomendaria',
+  intencao_continuar: 'considerando_no_continuar',
+};
+
+describe('Survey end-to-end', () => {
+  let app: INestApplication;
+  let cookie: string;
+
+  beforeAll(async () => {
+    app = await createTestApp();
+    cookie = await loginAsAdmin(app);
+  });
+
+  afterAll(async () => {
+    if (app) await app.close();
+  });
+
+  // ─── Period generation ──────────────────────────────────────────────
+
+  let periodId: string;
+  let firstToken: string;
+  let firstTurmaCodigo: string;
+
+  it('admin can generate a period with one token per active student', async () => {
+    const resp = await request(app.getHttpServer())
+      .post('/api/admin/pesquisas/gerar')
+      .set('Cookie', cookie)
+      .send({ mes: 5, ano: 2026 })
+      .expect(201);
+
+    expect(resp.body.period).toBeDefined();
+    expect(resp.body.period.id).toMatch(/^[0-9a-f-]{36}$/);
+    expect(resp.body.tokens_created).toBeGreaterThan(0);
+    periodId = resp.body.period.id;
+  });
+
+  it('refuses to regenerate the same (mes, ano)', async () => {
+    await request(app.getHttpServer())
+      .post('/api/admin/pesquisas/gerar')
+      .set('Cookie', cookie)
+      .send({ mes: 5, ano: 2026 })
+      .expect(409);
+  });
+
+  it('rejects invalid month/year', async () => {
+    await request(app.getHttpServer())
+      .post('/api/admin/pesquisas/gerar')
+      .set('Cookie', cookie)
+      .send({ mes: 13, ano: 2026 })
+      .expect(400);
+    await request(app.getHttpServer())
+      .post('/api/admin/pesquisas/gerar')
+      .set('Cookie', cookie)
+      .send({ mes: 5, ano: 1999 })
+      .expect(400);
+  });
+
+  it('admin list shows the new period with token totals', async () => {
+    const resp = await request(app.getHttpServer())
+      .get('/api/admin/pesquisas')
+      .set('Cookie', cookie)
+      .expect(200);
+
+    expect(Array.isArray(resp.body)).toBe(true);
+    const found = resp.body.find((p: any) => p.id === periodId);
+    expect(found).toBeDefined();
+    expect(found.tokens_total).toBeGreaterThan(0);
+    expect(found.tokens_respondidos).toBe(0);
+  });
+
+  // ─── WhatsApp messages give us the tokens ───────────────────────────
+
+  it('whatsapp messages endpoint returns one entry per turma with copy-pastable text', async () => {
+    const resp = await request(app.getHttpServer())
+      .get(`/api/admin/pesquisas/${periodId}/mensagens-whatsapp`)
+      .set('Cookie', cookie)
+      .expect(200);
+
+    expect(resp.body.period).toEqual({ mes: 5, ano: 2026 });
+    expect(resp.body.turmas.length).toBeGreaterThan(0);
+    const sample = resp.body.turmas[0];
+    expect(sample.turma_nome).toBeTruthy();
+    expect(sample.alunos_count).toBeGreaterThan(0);
+    expect(sample.mensagem).toContain('mayo');
+
+    // Pull a real token out of the message — the format is
+    // "Nombre → /p/<token>" (or a full URL when PUBLIC_BASE_URL is set).
+    const match = sample.mensagem.match(/\/p\/([a-z0-9]{12})/);
+    expect(match).toBeTruthy();
+    firstToken = match![1];
+    firstTurmaCodigo = sample.turma_codigo;
+  });
+
+  // ─── Public token validation ────────────────────────────────────────
+
+  it('public GET returns the survey context for a valid token, no auth', async () => {
+    const resp = await request(app.getHttpServer())
+      .get(`/api/pesquisa/${firstToken}/info`)
+      .expect(200);
+
+    expect(resp.body).toMatchObject({
+      mes_referencia: 5,
+      ano_referencia: 2026,
+    });
+    expect(resp.body.turma_nome).toBeTruthy();
+  });
+
+  it('public GET 404s on an invalid token', async () => {
+    await request(app.getHttpServer())
+      .get('/api/pesquisa/notarealtoken/info')
+      .expect(404);
+  });
+
+  // ─── Submit ─────────────────────────────────────────────────────────
+
+  it('rejects submissions missing required fields', async () => {
+    await request(app.getHttpServer())
+      .post(`/api/pesquisa/${firstToken}`)
+      .send({ nota_aulas: 5 })
+      .expect(400);
+  });
+
+  it('rejects submissions with values outside the allowed enum', async () => {
+    await request(app.getHttpServer())
+      .post(`/api/pesquisa/${firstToken}`)
+      .send({ ...VALID_RESPONSE, recomendacao: 'no-existe' })
+      .expect(400);
+  });
+
+  it('accepts a valid submission and stores the response without aluno_codigo', async () => {
+    await request(app.getHttpServer())
+      .post(`/api/pesquisa/${firstToken}`)
+      .send(VALID_RESPONSE)
+      .expect(201);
+
+    // Reach into the DB and confirm the response row has no aluno_codigo.
+    const ds = app.get(DataSource);
+    const repo = ds.getRepository(SurveyResponse);
+    const rows = await repo.find();
+    expect(rows.length).toBe(1);
+    expect(rows[0]).not.toHaveProperty('aluno_codigo');
+    // Belt and braces: the SQL columns exposed by metadata also exclude it.
+    const cols = ds.getMetadata(SurveyResponse).columns.map((c) => c.propertyName);
+    expect(cols).not.toContain('aluno_codigo');
+  });
+
+  it('rejects re-using a token after it was responded', async () => {
+    await request(app.getHttpServer())
+      .post(`/api/pesquisa/${firstToken}`)
+      .send(VALID_RESPONSE)
+      .expect(410);
+  });
+
+  // ─── Aggregations & alerts ──────────────────────────────────────────
+
+  it('period detail reflects the response and exposes NPS', async () => {
+    const resp = await request(app.getHttpServer())
+      .get(`/api/admin/pesquisas/${periodId}`)
+      .set('Cookie', cookie)
+      .expect(200);
+
+    expect(resp.body.summary.respondidas).toBe(1);
+    expect(resp.body.summary.media_aulas).toBe(5);
+    // 1/1 promoter → NPS 100
+    expect(resp.body.summary.nps).toBe(100);
+    expect(resp.body.por_turma.length).toBeGreaterThan(0);
+  });
+
+  it('turma detail surfaces the response without leaking aluno_codigo', async () => {
+    const resp = await request(app.getHttpServer())
+      .get(`/api/admin/pesquisas/${periodId}/turma/${firstTurmaCodigo}`)
+      .set('Cookie', cookie)
+      .expect(200);
+
+    expect(resp.body.respostas.length).toBeGreaterThanOrEqual(1);
+    for (const r of resp.body.respostas) {
+      expect(r).not.toHaveProperty('aluno_codigo');
+    }
+  });
+
+  it('a critical response triggers alerts that show on detail', async () => {
+    // Need a second token from a different student. Pull one from the
+    // whatsapp endpoint and submit a critical response.
+    const wResp = await request(app.getHttpServer())
+      .get(`/api/admin/pesquisas/${periodId}/mensagens-whatsapp`)
+      .set('Cookie', cookie)
+      .expect(200);
+
+    let alarmingToken: string | null = null;
+    for (const turma of wResp.body.turmas) {
+      const matches = [...turma.mensagem.matchAll(/\/p\/([a-z0-9]{12})/g)];
+      const candidate = matches.map((m) => m[1]).find((t) => t !== firstToken);
+      if (candidate) {
+        alarmingToken = candidate;
+        break;
+      }
+    }
+    expect(alarmingToken).toBeTruthy();
+
+    await request(app.getHttpServer())
+      .post(`/api/pesquisa/${alarmingToken}`)
+      .send(CRITICAL_RESPONSE)
+      .expect(201);
+
+    const detail = await request(app.getHttpServer())
+      .get(`/api/admin/pesquisas/${periodId}`)
+      .set('Cookie', cookie)
+      .expect(200);
+
+    const tipos = new Set(detail.body.alertas.map((a: any) => a.tipo));
+    expect(tipos).toContain('intencao_critica');
+    expect(tipos).toContain('nota_aulas_baixa');
+    expect(tipos).toContain('nota_professor_baixa');
+  });
+
+  // ─── Auth ───────────────────────────────────────────────────────────
+
+  it('admin endpoints require authentication', async () => {
+    await request(app.getHttpServer())
+      .get('/api/admin/pesquisas')
+      .expect(401);
+    await request(app.getHttpServer())
+      .post('/api/admin/pesquisas/gerar')
+      .send({ mes: 6, ano: 2026 })
+      .expect(401);
+  });
+});

--- a/test/survey.e2e-spec.ts
+++ b/test/survey.e2e-spec.ts
@@ -96,7 +96,7 @@ describe('Survey end-to-end', () => {
 
   // ─── WhatsApp messages give us the tokens ───────────────────────────
 
-  it('whatsapp messages endpoint returns one entry per turma with copy-pastable text', async () => {
+  it('whatsapp endpoint emits per-student messages, never aggregating tokens', async () => {
     const resp = await request(app.getHttpServer())
       .get(`/api/admin/pesquisas/${periodId}/mensagens-whatsapp`)
       .set('Cookie', cookie)
@@ -107,13 +107,28 @@ describe('Survey end-to-end', () => {
     const sample = resp.body.turmas[0];
     expect(sample.turma_nome).toBeTruthy();
     expect(sample.alunos_count).toBeGreaterThan(0);
-    expect(sample.mensagem).toContain('mayo');
+    expect(sample.alunos).toHaveLength(sample.alunos_count);
 
-    // Pull a real token out of the message — the format is
-    // "Nombre → /p/<token>" (or a full URL when PUBLIC_BASE_URL is set).
-    const match = sample.mensagem.match(/\/p\/([a-z0-9]{12})/);
-    expect(match).toBeTruthy();
-    firstToken = match![1];
+    // The shape is per-student, never one block with all tokens — that's
+    // the whole point of the refactor: a message visible to a third
+    // party only burns one token, not the entire class.
+    expect(sample).not.toHaveProperty('mensagem');
+
+    // Each individual message contains exactly one /p/<token> link, and
+    // the token belongs to that very student (cross-checked via the
+    // first-name greeting).
+    for (const turma of resp.body.turmas) {
+      for (const aluno of turma.alunos) {
+        const tokens = [...aluno.mensagem.matchAll(/\/p\/([a-z0-9]{12})/g)];
+        expect(tokens).toHaveLength(1);
+        const firstName = aluno.aluno_nome.split(/\s+/)[0];
+        expect(aluno.mensagem).toContain(`¡Hola ${firstName}!`);
+      }
+    }
+
+    const firstAluno = sample.alunos[0];
+    expect(firstAluno.mensagem).toContain('mayo');
+    firstToken = firstAluno.mensagem.match(/\/p\/([a-z0-9]{12})/)![1];
     firstTurmaCodigo = sample.turma_codigo;
   });
 
@@ -213,12 +228,13 @@ describe('Survey end-to-end', () => {
       .expect(200);
 
     let alarmingToken: string | null = null;
-    for (const turma of wResp.body.turmas) {
-      const matches = [...turma.mensagem.matchAll(/\/p\/([a-z0-9]{12})/g)];
-      const candidate = matches.map((m) => m[1]).find((t) => t !== firstToken);
-      if (candidate) {
-        alarmingToken = candidate;
-        break;
+    outer: for (const turma of wResp.body.turmas) {
+      for (const aluno of turma.alunos) {
+        const m = aluno.mensagem.match(/\/p\/([a-z0-9]{12})/);
+        if (m && m[1] !== firstToken) {
+          alarmingToken = m[1];
+          break outer;
+        }
       }
     }
     expect(alarmingToken).toBeTruthy();


### PR DESCRIPTION
## Sumário

Implementa o sistema mensal de pesquisa de satisfação dos alunos conforme `PESQUISA_SATISFACAO_SPEC.md`. Cada aluno ativo recebe um link único por mês, responde de forma anônima, e a coordenação tem painel para gerar tokens, ler respostas e copiar mensagens prontas para WhatsApp.

**6 commits semânticos** (sem squash):

- `feat(survey): add entities, DTOs, constants and token generator`
- `feat(survey): add period, response and analytics services`
- `feat(survey): wire controllers, module and HTML route exclusions`
- `test(survey): cover token gen, alerts, and full e2e flow`
- `feat(survey): public student survey page (Spanish, mobile-first)`
- `feat(survey): admin panel for survey periods (Portuguese)`

## O que foi entregue

### Backend (`src/survey/`)
- 4 entities — `SurveyPeriod`, `SurveyToken`, `SurveyResponse` (sem `aluno_codigo` por design), `SurveyAlert`
- 4 services — geração de período + lote de tokens, submit transacional com atomic UPDATE, agregações (NPS, médias, distribuição de intenção), abstração da busca de alunos no Q10
- 3 controllers — admin (JWT), AJAX público com rate-limit (10 POST/h, 30 GET/h), páginas HTML
- Endpoints da spec, todos cobertos:
  - `POST /api/admin/pesquisas/gerar`
  - `GET  /api/admin/pesquisas`
  - `GET  /api/admin/pesquisas/:id`
  - `GET  /api/admin/pesquisas/:id/turma/:turmaId`
  - `GET  /api/admin/pesquisas/:id/mensagens-whatsapp`
  - `GET  /api/pesquisa/:token/info` *(antes era `/api/pesquisa/:token` GET — ver decisão #5 abaixo)*
  - `POST /api/pesquisa/:token`
  - `GET  /pesquisa`, `/pesquisa/:token`, `/p/:token` (HTML, fora de `/api`)

### Frontend
- **Aluno** (espanhol, mobile-first) em `public/pesquisa/` — form de 4 seções com barra de progresso, paleta navy/dourado, fontes Cinzel/Montserrat
- **Admin** (pt-BR) em `public/admin/pesquisas/` — SPA com hash routing: listagem → detalhe (KPIs + WhatsApp blocks com copy-to-clipboard + tabela por turma + alertas) → respostas anônimas de uma turma. Reaproveita o login JWT existente (401 → redirect para `/dashboard`)

### Testes
- 17 suites, 173 testes — todos verdes
- Novos: `test/survey-token-generator.spec.ts`, `test/survey-alerts.spec.ts`, `test/survey.e2e-spec.ts`
- E2e cobre o fluxo completo: gerar período, recusar duplicata, validar token, submeter, recusar segundo submit (410), DTO inválido (400), disparo de alertas críticos, auth obrigatório no admin, e verificação de metadata confirmando que **`aluno_codigo` não existe** na tabela de respostas

## Decisões a revisar

1. **`src/survey/`** em vez de `src/modules/survey/` que a spec sugeria — segui a convenção existente (`src/<modulo>/`).
2. **Sem migrations criadas** — o projeto usa `synchronize: true` e tem comentário explícito em `app.module.ts:38` flagando migrations como v2. Mantive a convenção; as novas entities são criadas no primeiro boot.
3. **Linkagem aluno→turma simplificada** — o Q10 não expõe um join limpo aluno↔curso nos endpoints atuais (`/estudiantes` só tem `Codigo_programa`). Estou agrupando por programa e elegendo o professor dominante por programa. Em produção, quando a operadora quiser granularidade por seção/horário, ajustar `StudentSourceService.fetchActiveStudentsForSurvey`.
4. **Paleta** — a spec falava em azul/laranja (`#0EA5E9`/`#F97316`) mas o site real usa navy `#000E38` + dourado `#DCAF63` (Cinzel/Montserrat). Segui a identidade do site, não da spec.
5. **GET AJAX moveu para `/api/pesquisa/:token/info`** — a exclusão do prefixo `/api` que a rota HTML precisa colapsava ambos no mesmo path GET. Sufixo `/info` evita o conflito sem mexer no path do POST que a spec definiu.
6. **TOCTOU no submit** resolvido com `UPDATE survey_tokens SET usado_em = ? WHERE id = ? AND usado_em IS NULL` em vez de pessimistic lock (better-sqlite3 não suporta; o approach é portável para Postgres).
7. **URL pública** das mensagens WhatsApp usa nova env opcional `PUBLIC_BASE_URL` (se ausente, emite path relativo `/p/:token`).

## Test plan

- [x] `npm run build` passa sem warnings novos
- [x] `npm test` — 173/173 verdes
- [ ] Subir em ambiente de staging com Q10 real e:
  - [ ] Gerar período do mês corrente
  - [ ] Abrir alguns links em mobile e desktop
  - [ ] Submeter respostas (uma normal, uma com `intencao_continuar=considerando_no_continuar`)
  - [ ] Conferir no painel admin que aparecem nas estatísticas, no detalhe da turma e que o alerta crítico foi gravado
  - [ ] Verificar que o link `/p/:token` redireciona para `/pesquisa/:token`
  - [ ] Tentar submeter o mesmo token duas vezes — segunda deve dar mensagem de "ya respondida"
- [ ] Definir `PUBLIC_BASE_URL` no `.env` de produção para as mensagens WhatsApp saírem com URL absoluta

🤖 Generated with [Claude Code](https://claude.com/claude-code)